### PR TITLE
removing parameter.Key == "timeout" because timeout in the HttpClient

### DIFF
--- a/src/Telegram.Bot/Api.cs
+++ b/src/Telegram.Bot/Api.cs
@@ -832,11 +832,12 @@ namespace Telegram.Bot
                             {
                                 var content = ConvertParameterValue(parameter.Value);
 
-                                if (parameter.Key == "timeout")
+/*                                
+								if (parameter.Key == "timeout")
                                 {
                                     client.Timeout = TimeSpan.FromSeconds((int)parameter.Value + 1);
                                 }
-
+*/
                                 if (parameter.Value is FileToSend)
                                 {
                                     client.Timeout = UploadTimeout;


### PR DESCRIPTION
Hi there. 
There is a problem with the timeout parameter used in the getUpdates method. When you send 0 (default value), the HttpClient timeout is set to 1 secs.