### PR TITLE
fixed UnixDateTimeConverter

### DIFF
--- a/src/Telegram.Bot/Helpers/UnixDatetimeConverter.cs
+++ b/src/Telegram.Bot/Helpers/UnixDatetimeConverter.cs
@@ -17,11 +17,7 @@ namespace Telegram.Bot.Helpers
             long val;
             if (value is DateTime)
             {
-#if NET45
                 val = ((DateTime)value).ToUnixTime();
-#else
-                val = new DateTimeOffset((DateTime) value).ToUnixTimeSeconds();
-#endif
             }
             else
             {
@@ -46,11 +42,7 @@ namespace Telegram.Bot.Helpers
 
             var ticks = (long)reader.Value;
 
-#if NET45
             return ticks.FromUnixTime();
-#else
-            return DateTimeOffset.FromUnixTimeSeconds(ticks).Date;
-#endif
         }
     }
 }


### PR DESCRIPTION
For .NET 4.6.1 there were a problem with Message.Date property: after deserializing it contained only Date part, but not Time (so all messages, received in the same day, had the same value of this property)