### PR TITLE
Added default implementation for PhotoSizeConverter.WriteJson

### DIFF
--- a/src/Telegram.Bot/Converters/PhotoSizeConverter.cs
+++ b/src/Telegram.Bot/Converters/PhotoSizeConverter.cs
@@ -8,13 +8,7 @@ namespace Telegram.Bot.Converters
     internal class PhotoSizeConverter : JsonConverter
     {
         public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
-        {
-            if (value == null)
-            {
-                return;
-            }
-            JObject.FromObject(value).WriteTo(writer);
-        }
+            => JObject.FromObject(value).WriteTo(writer);
 
         public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
         {

--- a/src/Telegram.Bot/Converters/PhotoSizeConverter.cs
+++ b/src/Telegram.Bot/Converters/PhotoSizeConverter.cs
@@ -9,7 +9,11 @@ namespace Telegram.Bot.Converters
     {
         public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
         {
-            throw new NotImplementedException();
+            if (value == null)
+            {
+                return;
+            }
+            JObject.FromObject(value).WriteTo(writer);
         }
 
         public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)


### PR DESCRIPTION
It's now possible to log received updates with `JsonConvert.SerializeObject(update)`