### PR TITLE
Patch DateTime min value for JsonConvert

### DIFF
--- a/src/Telegram.Bot/Converters/UnixDatetimeConverter.cs
+++ b/src/Telegram.Bot/Converters/UnixDatetimeConverter.cs
@@ -29,9 +29,9 @@ namespace Telegram.Bot.Converters
             if (value is DateTime || value is Nullable<DateTime>)
             {
 #if NET46
-                val = new DateTimeOffset((DateTime)value).ToUnixTimeSeconds();
+                val = (DateTime) value == DateTime.MinValue ? -62135596800L : new DateTimeOffset((DateTime)value).ToUnixTimeSeconds();
 #else
-                val = ((DateTime)value).ToUnixTime();
+                val = (DateTime) value == DateTime.MinValue ? -62135596800L : ((DateTime)value).ToUnixTime();
 #endif
             }
             else


### PR DESCRIPTION
If server time zone has a positive UTC timezone (UTC +3 for example), using `JsonConvert.SerializeObject()` on a CallbackQuery will throw am `ArgumentOutOfRangeException` with the message 

> The UTC time represented when the offset is applied must be between year 0 and 10,000.

1970 is the DateTimeOffset.MinValue, which doesn't cause any errors with this.
