### PR TITLE
OnReceiveGeneralError for all exceptions

### DIFF
--- a/src/Telegram.Bot/Args/ReceiveGeneralErrorEventArgs.cs
+++ b/src/Telegram.Bot/Args/ReceiveGeneralErrorEventArgs.cs
@@ -15,10 +15,10 @@ namespace Telegram.Bot.Args
         /// <value>
         /// The exception.
         /// </value>
-        public Exception Exception { get; private set; }
+        public Exception Exception { get; }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="ReceiveErrorEventArgs"/> class.
+        /// Initializes a new instance of the <see cref="ReceiveGeneralErrorEventArgs"/> class.
         /// </summary>
         /// <param name="exception">The general exception.</param>
         internal ReceiveGeneralErrorEventArgs(Exception exception)

--- a/src/Telegram.Bot/Args/ReceiveGeneralErrorEventArgs.cs
+++ b/src/Telegram.Bot/Args/ReceiveGeneralErrorEventArgs.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using Telegram.Bot.Exceptions;
+
+namespace Telegram.Bot.Args
+{
+    /// <summary>
+    /// <see cref="EventArgs"/> containing a general <see cref="Exception"/>
+    /// </summary>
+    /// <seealso cref="EventArgs" />
+    public class ReceiveGeneralErrorEventArgs : EventArgs
+    {
+        /// <summary>
+        /// Gets the exception.
+        /// </summary>
+        /// <value>
+        /// The exception.
+        /// </value>
+        public Exception Exception { get; private set; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ReceiveErrorEventArgs"/> class.
+        /// </summary>
+        /// <param name="exception">The general exception.</param>
+        internal ReceiveGeneralErrorEventArgs(Exception exception)
+        {
+            Exception = exception;
+        }
+
+        /// <summary>
+        /// Performs an implicit conversion from <see cref="Exception"/> to <see cref="ReceiveGeneralErrorEventArgs"/>.
+        /// </summary>
+        /// <param name="e">The <see cref="Exception"/></param>
+        /// <returns>
+        /// The result of the conversion.
+        /// </returns>
+        public static implicit operator ReceiveGeneralErrorEventArgs(Exception e) => new ReceiveGeneralErrorEventArgs(e);
+    }
+}

--- a/src/Telegram.Bot/TelegramBotClient.cs
+++ b/src/Telegram.Bot/TelegramBotClient.cs
@@ -187,6 +187,11 @@ namespace Telegram.Bot
         /// <summary>
         /// Occurs when an error occures during the background update pooling.
         /// </summary>
+        public event EventHandler<ReceiveGeneralErrorEventArgs> OnReceiveGeneralError;
+
+        /// <summary>
+        /// Occurs when an error occures during the background update pooling.
+        /// </summary>
         [Obsolete("Use OnReceiveError")]
         public event EventHandler<ReceiveErrorEventArgs> ReceiveError
         {
@@ -280,10 +285,14 @@ namespace Telegram.Bot
                         MessageOffset = update.Id + 1;
                     }
                 }
-                catch (OperationCanceledException) {}
-                catch (ApiRequestException e)
+                catch (OperationCanceledException) { }
+                catch (ApiRequestException apiException)
                 {
-                    OnReceiveError?.Invoke(this, e);
+                    OnReceiveError?.Invoke(this, apiException);
+                }
+                catch (Exception generalException)
+                {
+                    OnReceiveGeneralError?.Invoke(this, generalException);
                 }
             }
 


### PR DESCRIPTION
The ReceiveAsync function is making the host application crash when there is a network error, for example a disconnection.

I propose catching the exception and raising an event to let the user decide what to do with it.

The recommendation would be to call StopReceiving and probably call StartReceiving at a later time to do a reconnection.
