### PR TITLE
fix for VenueMessages being wrongly attributed as LocationMessages

### DIFF
--- a/src/Telegram.Bot/Types/Message.cs
+++ b/src/Telegram.Bot/Types/Message.cs
@@ -257,14 +257,14 @@ namespace Telegram.Bot.Types
                 if (Contact != null)
                     return MessageType.ContactMessage;
 
+                if (Venue != null)
+                    return MessageType.VenueMessage;
+
                 if (Location != null)
                     return MessageType.LocationMessage;
 
                 if (Text != null)
                     return MessageType.TextMessage;
-
-                if (Venue != null)
-                    return MessageType.VenueMessage;
 
                 if (NewChatMember != null ||
                     LeftChatMember != null ||


### PR DESCRIPTION
as VenueMessages also contain a location, they will automatically be assigned as LocationMessages. checking for the Venue property first before the location property should fix this.