### PR TITLE
add overload to send audio method with message caption

### DIFF
--- a/src/Telegram.Bot/ITelegramBotClient.cs
+++ b/src/Telegram.Bot/ITelegramBotClient.cs
@@ -47,7 +47,7 @@ namespace Telegram.Bot
         /// Occurs when an <see cref="Update"/> is received.
         /// </summary>
         event EventHandler<UpdateEventArgs> OnUpdate;
- 
+
         /// <summary>
         /// Occurs when a <see cref="Message"/> is recieved.
         /// </summary>
@@ -423,6 +423,27 @@ namespace Telegram.Bot
         /// <summary>
         /// Use this method to send audio files, if you want Telegram clients to display them in the music player. Your audio must be in the .mp3 format. On success, the sent Message is returned. Bots can currently send audio files of up to 50 MB in size, this limit may be changed in the future.
         /// </summary>
+        /// <param name="chatId">Unique identifier for the target chat</param>
+        /// <param name="audio">Audio file to send. You can either pass a file_id as String to resend an audio that is already on the Telegram servers, or upload a new audio file using multipart/form-data.</param>
+        /// <param name="duration">Duration of the audio in seconds</param>
+        /// <param name="performer">Performer</param>
+        /// <param name="title">Track name</param>
+        /// <param name="caption">Message caption</param>
+        /// <param name="disableNotification">Sends the message silently. iOS users will not receive a notification, Android users will receive a notification with no sound.</param>
+        /// <param name="replyToMessageId">Optional. If the message is a reply, ID of the original message</param>
+        /// <param name="replyMarkup">Optional. Additional interface options. A JSON-serialized object for a custom reply keyboard, instructions to hide keyboard or to force a reply from the user.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <returns>On success, the sent Message is returned.</returns>
+        Task<Message> SendAudioAsync(long chatId, FileToSend audio, int duration, string performer, string title,
+            string caption,
+            bool disableNotification = false,
+            int replyToMessageId = 0,
+            IReplyMarkup replyMarkup = null,
+            CancellationToken cancellationToken = default(CancellationToken));
+
+        /// <summary>
+        /// Use this method to send audio files, if you want Telegram clients to display them in the music player. Your audio must be in the .mp3 format. On success, the sent Message is returned. Bots can currently send audio files of up to 50 MB in size, this limit may be changed in the future.
+        /// </summary>
         /// <param name="chatId">Username of the target channel (in the format @channelusername)</param>
         /// <param name="audio">Audio file to send. You can either pass a file_id as String to resend an audio that is already on the Telegram servers, or upload a new audio file using multipart/form-data.</param>
         /// <param name="duration">Duration of the audio in seconds</param>
@@ -432,13 +453,15 @@ namespace Telegram.Bot
         /// <param name="replyToMessageId">Optional. If the message is a reply, ID of the original message</param>
         /// <param name="replyMarkup">Optional. Additional interface options. A JSON-serialized object for a custom reply keyboard, instructions to hide keyboard or to force a reply from the user.</param>
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <param name="caption">Message caption</param>
         /// <returns>On success, the sent Message is returned.</returns>
         Task<Message> SendAudioAsync(string chatId, FileToSend audio, int duration, string performer,
             string title,
             bool disableNotification = false,
             int replyToMessageId = 0,
             IReplyMarkup replyMarkup = null,
-            CancellationToken cancellationToken = default(CancellationToken));
+            CancellationToken cancellationToken = default(CancellationToken),
+            string caption = null);
 
         /// <summary>
         /// Use this method to send audio files, if you want Telegram clients to display the file as a playable voice message. For this to work, your audio must be in an .ogg file encoded with OPUS (other formats may be sent as Document). On success, the sent Message is returned. Bots can send audio files of up to 50 MB in size.

--- a/src/Telegram.Bot/TelegramBotClient.cs
+++ b/src/Telegram.Bot/TelegramBotClient.cs
@@ -791,6 +791,31 @@ namespace Telegram.Bot
         /// <summary>
         /// Use this method to send audio files, if you want Telegram clients to display them in the music player. Your audio must be in the .mp3 format. On success, the sent Message is returned. Bots can currently send audio files of up to 50 MB in size, this limit may be changed in the future.
         /// </summary>
+        /// <param name="chatId">Unique identifier for the target chat</param>
+        /// <param name="audio">Audio file to send. You can either pass a file_id as String to resend an audio that is already on the Telegram servers, or upload a new audio file using multipart/form-data.</param>
+        /// <param name="duration">Duration of the audio in seconds</param>
+        /// <param name="performer">Performer</param>
+        /// <param name="title">Track name</param>
+        /// <param name="caption">Message caption</param>
+        /// <param name="disableNotification">Sends the message silently. iOS users will not receive a notification, Android users will receive a notification with no sound.</param>
+        /// <param name="replyToMessageId">Optional. If the message is a reply, ID of the original message</param>
+        /// <param name="replyMarkup">Optional. Additional interface options. A JSON-serialized object for a custom reply keyboard, instructions to hide keyboard or to force a reply from the user.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <returns>On success, the sent Message is returned.</returns>
+        public Task<Message> SendAudioAsync(long chatId, FileToSend audio, int duration, string performer, string title,
+            string caption,
+            bool disableNotification = false,
+            int replyToMessageId = 0,
+            IReplyMarkup replyMarkup = null,
+            CancellationToken cancellationToken = default(CancellationToken))
+            =>
+                SendAudioAsync(chatId.ToString(), audio, duration, performer, title, disableNotification,
+                    replyToMessageId,
+                    replyMarkup, cancellationToken, caption);
+
+        /// <summary>
+        /// Use this method to send audio files, if you want Telegram clients to display them in the music player. Your audio must be in the .mp3 format. On success, the sent Message is returned. Bots can currently send audio files of up to 50 MB in size, this limit may be changed in the future.
+        /// </summary>
         /// <param name="chatId">Username of the target channel (in the format @channelusername)</param>
         /// <param name="audio">Audio file to send. You can either pass a file_id as String to resend an audio that is already on the Telegram servers, or upload a new audio file using multipart/form-data.</param>
         /// <param name="duration">Duration of the audio in seconds</param>
@@ -800,25 +825,44 @@ namespace Telegram.Bot
         /// <param name="replyToMessageId">Optional. If the message is a reply, ID of the original message</param>
         /// <param name="replyMarkup">Optional. Additional interface options. A JSON-serialized object for a custom reply keyboard, instructions to hide keyboard or to force a reply from the user.</param>
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <param name="caption">Message caption</param>
         /// <returns>On success, the sent Message is returned.</returns>
         public Task<Message> SendAudioAsync(string chatId, FileToSend audio, int duration, string performer,
             string title,
             bool disableNotification = false,
             int replyToMessageId = 0,
             IReplyMarkup replyMarkup = null,
-            CancellationToken cancellationToken = default(CancellationToken))
+            CancellationToken cancellationToken = default(CancellationToken),
+            string caption = null)
         {
             var additionalParameters = new Dictionary<string, object>
             {
                 {"duration", duration},
                 {"performer", performer},
-                {"title", title}
+                {"title", title},
             };
+            if (!string.IsNullOrEmpty(caption))
+                additionalParameters.Add("caption", caption);
 
             return SendMessageAsync(MessageType.AudioMessage, chatId, audio, disableNotification, replyToMessageId,
                 replyMarkup, additionalParameters, cancellationToken);
         }
+        public Task<Message> SendAudioAsync(string chatId, FileToSend audio, int duration, string performer, string title, string caption,
+           bool disableNotification = false,
+           int replyToMessageId = 0,
+           IReplyMarkup replyMarkup = null)
+        {
+            var additionalParameters = new Dictionary<string, object>
+            {
+                {"duration", duration},
+                {"performer", performer},
+                {"title", title},
+                {"caption", caption},
+            };
 
+            return SendMessageAsync(MessageType.AudioMessage, chatId, audio, disableNotification, replyToMessageId,
+                replyMarkup, additionalParameters);
+        }
         /// <summary>
         /// Use this method to send audio files, if you want Telegram clients to display the file as a playable voice message. For this to work, your audio must be in an .ogg file encoded with OPUS (other formats may be sent as Document). On success, the sent Message is returned. Bots can send audio files of up to 50 MB in size.
         /// </summary>


### PR DESCRIPTION
when audio send by bot, we can insert Bot Id(or any things) as caption to message audio.
e.g @GetMediaBot