### PR TITLE
Fix DeleteWebhookAsync method

### DIFF
--- a/src/Telegram.Bot/TelegramBotClient.cs
+++ b/src/Telegram.Bot/TelegramBotClient.cs
@@ -370,7 +370,7 @@ namespace Telegram.Bot
         /// <returns>Returns true on success</returns>
         /// <see href="https://core.telegram.org/bots/api#deletewebhook"/>
         public Task<bool> DeleteWebhookAsync(CancellationToken cancellationToken = default(CancellationToken))
-            => SendWebRequestAsync<bool>("removeWebhook", null, cancellationToken);
+            => SendWebRequestAsync<bool>("deleteWebhook", null, cancellationToken);
 
         /// <summary>
         /// Use this method to get current webhook status.


### PR DESCRIPTION
Should be `deleteWebhook` instead of `removeWebhook`.

See [api#deletewebhook](https://core.telegram.org/bots/api#deletewebhook)