### PR TITLE
Fix AnswerPreCheckoutQuery method's incorrect name

### DIFF
--- a/src/Telegram.Bot/ITelegramBotClient.cs
+++ b/src/Telegram.Bot/ITelegramBotClient.cs
@@ -766,7 +766,7 @@ namespace Telegram.Bot
         /// <returns>On success, True is returned.</returns>
         /// <remarks>Note: The Bot API must receive an answer within 10 seconds after the pre-checkout query was sent.</remarks>
         /// <see href="https://core.telegram.org/bots/api#answerprecheckoutquery"/>
-        Task<bool> AnswerPreCheckoutQuery(string preCheckoutQueryId, bool ok,
+        Task<bool> AnswerPreCheckoutQueryAsync(string preCheckoutQueryId, bool ok,
             string errorMessage = null,
             CancellationToken cancellationToken = default(CancellationToken));
 

--- a/src/Telegram.Bot/TelegramBotClient.cs
+++ b/src/Telegram.Bot/TelegramBotClient.cs
@@ -1363,7 +1363,7 @@ namespace Telegram.Bot
         /// <returns>On success, True is returned.</returns>
         /// <remarks>Note: The Bot API must receive an answer within 10 seconds after the pre-checkout query was sent.</remarks>
         /// <see href="https://core.telegram.org/bots/api#answerprecheckoutquery"/>
-        public Task<bool> AnswerPreCheckoutQuery(string preCheckoutQueryId, bool ok,
+        public Task<bool> AnswerPreCheckoutQueryAsync(string preCheckoutQueryId, bool ok,
             string errorMessage = null,
             CancellationToken cancellationToken = default(CancellationToken))
         {


### PR DESCRIPTION
In according to naming convention all async methods should be named with appending "Async" suffix.