### PR TITLE
Fixes #325 (fixed inline message editing)

### DIFF
--- a/src/Telegram.Bot/ITelegramBotClient.cs
+++ b/src/Telegram.Bot/ITelegramBotClient.cs
@@ -23,7 +23,7 @@ namespace Telegram.Bot
         /// Timeout for requests
         /// </summary>
         TimeSpan Timeout { get; set; }
-        
+
         /// <summary>
         /// Indecates if receiving updates
         /// </summary>
@@ -41,7 +41,7 @@ namespace Telegram.Bot
         /// Occurs when an <see cref="Update"/> is received.
         /// </summary>
         event EventHandler<UpdateEventArgs> OnUpdate;
- 
+
         /// <summary>
         /// Occurs when a <see cref="Message"/> is recieved.
         /// </summary>
@@ -349,7 +349,7 @@ namespace Telegram.Bot
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <returns>On success, the sent Message is returned.</returns>
         /// <see href="https://core.telegram.org/bots/api#sendvoice"/>
-        Task<Message> SendVoiceAsync(ChatId chatId, FileToSend voice, 
+        Task<Message> SendVoiceAsync(ChatId chatId, FileToSend voice,
             string caption = "",
             int duration = 0,
             bool disableNotification = false,
@@ -595,9 +595,9 @@ namespace Telegram.Bot
         /// <param name="disableWebPagePreview">Disables link previews for links in this message</param>
         /// <param name="replyMarkup">A JSON-serialized object for an inline keyboard.</param>
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
-        /// <returns>On success, the edited Message is returned.</returns>
+        /// <returns>><c>true</c> on success.</returns>
         /// <see href="https://core.telegram.org/bots/api#editmessagetext"/>
-        Task<Message> EditInlineMessageTextAsync(string inlineMessageId, string text,
+        Task<bool> EditInlineMessageTextAsync(string inlineMessageId, string text,
             ParseMode parseMode = ParseMode.Default,
             bool disableWebPagePreview = false,
             IReplyMarkup replyMarkup = null,
@@ -624,9 +624,9 @@ namespace Telegram.Bot
         /// <param name="caption">New caption of the message</param>
         /// <param name="replyMarkup">A JSON-serialized object for an inline keyboard.</param>
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
-        /// <returns>On success, the edited Message is returned.</returns>
+        /// <returns>><c>true</c> on success.</returns>
         /// <see href="https://core.telegram.org/bots/api#editmessagecaption"/>
-        Task<Message> EditInlineMessageCaptionAsync(string inlineMessageId, string caption,
+        Task<bool> EditInlineMessageCaptionAsync(string inlineMessageId, string caption,
             IReplyMarkup replyMarkup = null,
             CancellationToken cancellationToken = default(CancellationToken));
 
@@ -649,9 +649,9 @@ namespace Telegram.Bot
         /// <param name="inlineMessageId">Unique identifier of the sent message</param>
         /// <param name="replyMarkup">A JSON-serialized object for an inline keyboard.</param>
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
-        /// <returns>On success, the edited Message is returned.</returns>
+        /// <returns>><c>true</c> on success.</returns>
         /// <see href="https://core.telegram.org/bots/api#editmessagereplymarkup"/>
-        Task<Message> EditInlineMessageReplyMarkupAsync(string inlineMessageId,
+        Task<bool> EditInlineMessageReplyMarkupAsync(string inlineMessageId,
             IReplyMarkup replyMarkup = null,
             CancellationToken cancellationToken = default(CancellationToken));
 
@@ -734,7 +734,7 @@ namespace Telegram.Bot
             bool needName = false,
             bool needPhoneNumber = false,
             bool needEmail = false,
-            bool needShippingAddress= false,
+            bool needShippingAddress = false,
             bool isFlexible = false,
             bool disableNotification = false,
             int replyToMessageId = 0,

--- a/src/Telegram.Bot/TelegramBotClient.cs
+++ b/src/Telegram.Bot/TelegramBotClient.cs
@@ -1055,9 +1055,9 @@ namespace Telegram.Bot
         /// <param name="disableWebPagePreview">Disables link previews for links in this message</param>
         /// <param name="replyMarkup">A JSON-serialized object for an inline keyboard.</param>
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
-        /// <returns>On success, the edited Message is returned.</returns>
+        /// <returns>><c>true</c> on success.</returns>
         /// <see href="https://core.telegram.org/bots/api#editmessagetext"/>
-        public Task<Message> EditInlineMessageTextAsync(string inlineMessageId, string text,
+        public Task<bool> EditInlineMessageTextAsync(string inlineMessageId, string text,
             ParseMode parseMode = ParseMode.Default,
             bool disableWebPagePreview = false,
             IReplyMarkup replyMarkup = null,
@@ -1076,7 +1076,7 @@ namespace Telegram.Bot
             if (parseMode != ParseMode.Default)
                 parameters.Add("parse_mode", parseMode.ToModeString());
 
-            return SendWebRequestAsync<Message>("editMessageText", parameters, cancellationToken);
+            return SendWebRequestAsync<bool>("editMessageText", parameters, cancellationToken);
         }
 
         /// <summary>
@@ -1113,9 +1113,9 @@ namespace Telegram.Bot
         /// <param name="caption">New caption of the message</param>
         /// <param name="replyMarkup">A JSON-serialized object for an inline keyboard.</param>
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
-        /// <returns>On success, the edited Message is returned.</returns>
+        /// <returns>><c>true</c> on success.</returns>
         /// <see href="https://core.telegram.org/bots/api#editmessagecaption"/>
-        public Task<Message> EditInlineMessageCaptionAsync(string inlineMessageId, string caption,
+        public Task<bool> EditInlineMessageCaptionAsync(string inlineMessageId, string caption,
             IReplyMarkup replyMarkup = null,
             CancellationToken cancellationToken = default(CancellationToken))
         {
@@ -1128,7 +1128,7 @@ namespace Telegram.Bot
             if (replyMarkup != null)
                 parameters.Add("reply_markup", replyMarkup);
 
-            return SendWebRequestAsync<Message>("editMessageCaption", parameters, cancellationToken);
+            return SendWebRequestAsync<bool>("editMessageCaption", parameters, cancellationToken);
         }
 
         /// <summary>
@@ -1162,9 +1162,9 @@ namespace Telegram.Bot
         /// <param name="inlineMessageId">Unique identifier of the sent message</param>
         /// <param name="replyMarkup">A JSON-serialized object for an inline keyboard.</param>
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
-        /// <returns>On success, the edited Message is returned.</returns>
+        /// <returns>><c>true</c> on success.</returns>
         /// <see href="https://core.telegram.org/bots/api#editmessagereplymarkup"/>
-        public Task<Message> EditInlineMessageReplyMarkupAsync(string inlineMessageId,
+        public Task<bool> EditInlineMessageReplyMarkupAsync(string inlineMessageId,
             IReplyMarkup replyMarkup = null,
             CancellationToken cancellationToken = default(CancellationToken))
         {
@@ -1176,7 +1176,7 @@ namespace Telegram.Bot
             if (replyMarkup != null)
                 parameters.Add("reply_markup", replyMarkup);
 
-            return SendWebRequestAsync<Message>("editMessageReplyMarkup", parameters, cancellationToken);
+            return SendWebRequestAsync<bool>("editMessageReplyMarkup", parameters, cancellationToken);
         }
 
         /// <summary>
@@ -1635,10 +1635,11 @@ namespace Telegram.Bot
                 throw new ApiRequestException("Request timed out", 408, e);
             }
             catch (HttpRequestException e)
-                when (e.Message.Contains("400") || e.Message.Contains("403") || e.Message.Contains("409")) {}
+                when (e.Message.Contains("400") || e.Message.Contains("403") || e.Message.Contains("409"))
+            { }
 
             if (responseObject == null)
-                responseObject = new ApiResponse<T> {Ok = false, Message = "No response received"};
+                responseObject = new ApiResponse<T> { Ok = false, Message = "No response received" };
 
             if (!responseObject.Ok)
                 throw ApiRequestException.FromApiResponse(responseObject);


### PR DESCRIPTION
Fixes JSON parse exceptions while parsing the bool result from Telegram in the following methods: EditInlineMessageTextAsync, EditInlineMessageCaptionAsync and EditInlineMessageReplyMarkupAsync