### PR TITLE
User.Id and Chat.Id reverted to long

### DIFF
--- a/src/Telegram.Bot/Types/Chat.cs
+++ b/src/Telegram.Bot/Types/Chat.cs
@@ -13,7 +13,7 @@ namespace Telegram.Bot.Types
         /// Unique identifier for this chat, not exceeding 1e13 by absolute value
         /// </summary>
         [JsonProperty(PropertyName = "id", Required = Required.Always)]
-        public ChatId Id { get; set; }
+        public long Id { get; set; }
 
         /// <summary>
         /// Type of chat

--- a/src/Telegram.Bot/Types/User.cs
+++ b/src/Telegram.Bot/Types/User.cs
@@ -13,7 +13,7 @@ namespace Telegram.Bot.Types
         /// </summary>
         /// <returns></returns>
         [JsonProperty(PropertyName = "id", Required = Required.Always)]
-        public long Id { get; set; }
+        public int Id { get; set; }
 
         /// <summary>
         /// User's or bot's first name

--- a/src/Telegram.Bot/Types/User.cs
+++ b/src/Telegram.Bot/Types/User.cs
@@ -13,7 +13,7 @@ namespace Telegram.Bot.Types
         /// </summary>
         /// <returns></returns>
         [JsonProperty(PropertyName = "id", Required = Required.Always)]
-        public ChatId Id { get; set; }
+        public long Id { get; set; }
 
         /// <summary>
         /// User's or bot's first name


### PR DESCRIPTION
According to Telegram [documentation](https://core.telegram.org/bots/api#chat) Id of Chat and User can be only Integer.