### PR TITLE
Fix #358 typo in SetWebhookAsync method

### DIFF
--- a/src/Telegram.Bot/TelegramBotClient.cs
+++ b/src/Telegram.Bot/TelegramBotClient.cs
@@ -351,7 +351,7 @@ namespace Telegram.Bot
             var parameters = new Dictionary<string, object>
             {
                 {"url", url},
-                {"mac_connections", maxConnections}
+                {"max_connections", maxConnections}
             };
 
             if (allowedUpdates != null && !allowedUpdates.Contains(UpdateType.All))


### PR DESCRIPTION
According to [API documentations](https://core.telegram.org/bots/api#setwebhook), params should be named `max_connections ` not `mac_connections `