### PR TITLE
Make callback query data an optional property

### DIFF
--- a/src/Telegram.Bot/Types/CallbackQuery.cs
+++ b/src/Telegram.Bot/Types/CallbackQuery.cs
@@ -44,7 +44,7 @@ namespace Telegram.Bot.Types
         /// <remarks>
         /// Be aware that a bad client can send arbitrary data in this field.
         /// </remarks>
-        [JsonProperty("data", Required = Required.Always)]
+        [JsonProperty("data", Required = Required.Default)]
         public string Data { get; set; }
 
         /// <summary>


### PR DESCRIPTION
In the case of a game query, data in null.
This fixes the exceptions thrown in deserializing update payload when user clicks on _Play Game_ inline button.

[CallBackQuery on Telegram API](https://core.telegram.org/bots/api#callbackquery)