### PR TITLE
Fix #372 : SetGameScore response is not always a Message

### DIFF
--- a/src/Telegram.Bot/ITelegramBotClient.cs
+++ b/src/Telegram.Bot/ITelegramBotClient.cs
@@ -817,7 +817,7 @@ namespace Telegram.Bot
         /// <param name="disableEditMessage">Pass True, if the game message should not be automatically edited to include the current scoreboard</param>
         /// <param name="editMessage">Pass True, if the game message should be automatically edited to include the current scoreboard.</param>
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
-        /// <returns>On success, if the message was sent by the bot, returns the edited Message</returns>
+        /// <returns>On success, if the message was sent by the bot, returns the edited Message, otherwise return null.</returns>
         /// <see href="https://core.telegram.org/bots/api#setgamescore"/>
         Task<Message> SetGameScoreAsync(int userId, int score, string inlineMessageId,
             bool force = false,

--- a/src/Telegram.Bot/ITelegramBotClient.cs
+++ b/src/Telegram.Bot/ITelegramBotClient.cs
@@ -475,10 +475,11 @@ namespace Telegram.Bot
         /// <param name="chatId"><see cref="ChatId"/> for the target group</param>
         /// <param name="userId">Unique identifier of the target user</param>
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <param name="untilDate">Date when the user will be unbanned, unix time. If user is banned for more than 366 days or less than 30 seconds from the current time they are considered to be banned forever</param>
         /// <returns><c>true</c> on success.</returns>
         /// <see href="https://core.telegram.org/bots/api#kickchatmember"/>
         Task<bool> KickChatMemberAsync(ChatId chatId, int userId,
-            CancellationToken cancellationToken = default(CancellationToken));
+            CancellationToken cancellationToken = default(CancellationToken), int untilDate = 0);
 
         /// <summary>
         /// Use this method for your bot to leave a group, supergroup or channel.
@@ -563,6 +564,45 @@ namespace Telegram.Bot
             string url = null,
             int cacheTime = 0,
             CancellationToken cancellationToken = default(CancellationToken));
+
+        /// <summary>
+        /// Use this method to restrict a user in a supergroup. The bot must be an administrator in the supergroup for this to work and must have the appropriate admin rights.
+        /// </summary>
+        /// <param name="chatId">Unique identifier for the target chat or username of the target supergroup</param>
+        /// <param name="userId">Unique identifier of the target user</param>
+        /// <param name="untilDate">Date when restrictions will be lifted for the user, unix time. If user is restricted for more than 366 days or less than 30 seconds from the current time, they are considered to be restricted forever</param>
+        /// <param name="canSendMessages">Pass True, if the user can send text messages, contacts, locations and venues</param>
+        /// <param name="canSendMediaMessages">Pass True, if the user can send audios, documents, photos, videos, video notes and voice notes, implies can_send_messages</param>
+        /// <param name="canSendOtherMessages">Pass True, if the user can send animations, games, stickers and use inline bots, implies can_send_media_messages</param>
+        /// <param name="canAddWebPagePreviews">Pass True, if the user may add web page previews to their messages, implies can_send_media_messages</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <returns>On success, <c>true</c> is returned</returns>
+        /// <remarks>Pass True for all boolean parameters to lift restrictions from a user.</remarks>
+        Task<bool> RestrictChatMemberAsync(ChatId chatId, int userId, int untilDate = 0,
+            bool? canSendMessages = null, bool? canSendMediaMessages = null, bool? canSendOtherMessages = null,
+            bool? canAddWebPagePreviews = null,
+            CancellationToken cancellationToken = default(CancellationToken));
+
+        /// <summary>
+        /// Use this method to promote or demote a user in a supergroup or a channel. The bot must be an administrator in the chat for this to work and must have the appropriate admin rights.
+        /// </summary>
+        /// <param name="chatId">Unique identifier for the target chat or username of the target channel</param>
+        /// <param name="userId">Unique identifier of the target user</param>
+        /// <param name="canChangeInfo">Pass True, if the administrator can change chat title, photo and other settings</param>
+        /// <param name="canPostMessages">Pass True, if the administrator can create channel posts, channels only</param>
+        /// <param name="canEditMessages">Pass True, if the administrator can edit messages of other users, channels only</param>
+        /// <param name="canDeleteMessages">Pass True, if the administrator can delete messages of other users</param>
+        /// <param name="canInviteUsers">Pass True, if the administrator can invite new users to the chat</param>
+        /// <param name="canRestrictMembers">Pass True, if the administrator can restrict, ban or unban chat members</param>
+        /// <param name="canPinMessages">Pass True, if the administrator can pin messages, supergroups only</param>
+        /// <param name="canPromoteMembers">Pass True, if the administrator can add new administrators with a subset of his own privileges or demote administrators that he has promoted, directly or indirectly (promoted by administrators that were appointed by him)</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <returns>Returns True on success.</returns>
+        /// <remarks>Pass False for all boolean parameters to demote a user.</remarks>
+        Task<bool> PromoteChatMemberAsync(ChatId chatId, int userId, bool? canChangeInfo = null,
+            bool? canPostMessages = null, bool? canEditMessages = null, bool? canDeleteMessages = null,
+            bool? canInviteUsers = null, bool? canRestrictMembers = null, bool? canPinMessages = null,
+            bool? canPromoteMembers = null, CancellationToken cancellationToken = default(CancellationToken));
 
         #endregion Available methods
 
@@ -856,5 +896,75 @@ namespace Telegram.Bot
         Task<GameHighScore[]> GetGameHighScoresAsync(int userId, string inlineMessageId, CancellationToken cancellationToken = default(CancellationToken));
 
         #endregion Games
+
+        #region Group and channel management
+        /// <summary>
+        /// Use this method to export an invite link to a supergroup or a channel. The bot must be an administrator in the chat for this to work and must have the appropriate admin rights.
+        /// </summary>
+        /// <param name="chatId">Unique identifier for the target chat or username of the target channel</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <returns>Returns exported invite link as String on success.</returns>
+        Task<string> ExportChatInviteLinkAsync(ChatId chatId,
+            CancellationToken cancellationToken = default(CancellationToken));
+
+        /// <summary>
+        /// Use this method to set a new profile photo for the chat. Photos can't be changed for private chats. The bot must be an administrator in the chat for this to work and must have the appropriate admin rights.
+        /// </summary>
+        /// <param name="chatId">Unique identifier for the target chat or username of the target channel</param>
+        /// <param name="photo">The new profile picture for the chat.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <returns>Returns <c>true</c> on success.</returns>
+        Task<bool> SetChatPhotoAsync(ChatId chatId, FileToSend photo, 
+            CancellationToken cancellationToken = default(CancellationToken));
+
+        /// <summary>
+        /// Use this method to delete a chat photo. Photos can't be changed for private chats. The bot must be an administrator in the chat for this to work and must have the appropriate admin rights.
+        /// </summary>
+        /// <param name="chatId">Unique identifier for the target chat or username of the target channel</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <returns>Returns true on success.</returns>
+        Task<bool> DeleteChatPhotoAsync(ChatId chatId, CancellationToken cancellationToken = default(CancellationToken));
+
+        /// <summary>
+        /// Use this method to change the title of a chat. Titles can't be changed for private chats. The bot must be an administrator in the chat for this to work and must have the appropriate admin rights.
+        /// </summary>
+        /// <param name="chatId">Unique identifier for the target chat or username of the target channel</param>
+        /// <param name="title">New chat title, 1-255 characters</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <returns>Returns true on success.</returns>
+        Task<bool> SetChatTitleAsync(ChatId chatId, string title,
+            CancellationToken cancellationToken = default(CancellationToken));
+
+        /// <summary>
+        /// Use this method to change the description of a supergroup or a channel. The bot must be an administrator in the chat for this to work and must have the appropriate admin rights.
+        /// </summary>
+        /// <param name="chatId">Unique identifier for the target chat or username of the target channel</param>
+        /// <param name="description">New chat description, 0-255 characters</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <returns>Returns true on success.</returns>
+        Task<bool> SetChatDescriptionAsync(ChatId chatId, string description,
+            CancellationToken cancellationToken = default(CancellationToken));
+
+        /// <summary>
+        /// Use this method to pin a message in a supergroup. The bot must be an administrator in the chat for this to work and must have the appropriate admin rights.
+        /// </summary>
+        /// <param name="chatId">Unique identifier for the target chat or username of the target supergroup</param>
+        /// <param name="messageId">Identifier of a message to pin</param>
+        /// <param name="disableNotification">Pass True, if it is not necessary to send a notification to all group members about the new pinned message</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <returns>Returns true on success.</returns>
+        Task<bool> PinChatMessageAsync(ChatId chatId, int messageId, bool disableNotification = false,
+            CancellationToken cancellationToken = default(CancellationToken));
+
+        /// <summary>
+        /// Use this method to unpin a message in a supergroup chat. The bot must be an administrator in the chat for this to work and must have the appropriate admin rights.
+        /// </summary>
+        /// <param name="chatId">Unique identifier for the target chat or username of the target supergroup</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <returns>Returns true on success</returns>
+        Task<bool> UnpinChatMessageAsync(ChatId chatId, CancellationToken cancellationToken = default(CancellationToken));
+
+
+        #endregion
     }
 }

--- a/src/Telegram.Bot/Telegram.Bot.csproj
+++ b/src/Telegram.Bot/Telegram.Bot.csproj
@@ -25,7 +25,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="10.0.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
   </ItemGroup>
 
 </Project>

--- a/src/Telegram.Bot/TelegramBotClient.cs
+++ b/src/Telegram.Bot/TelegramBotClient.cs
@@ -351,7 +351,7 @@ namespace Telegram.Bot
             var parameters = new Dictionary<string, object>
             {
                 {"url", url},
-                {"mac_connections", maxConnections}
+                {"max_connections", maxConnections}
             };
 
             if (allowedUpdates != null && !allowedUpdates.Contains(UpdateType.All))

--- a/src/Telegram.Bot/TelegramBotClient.cs
+++ b/src/Telegram.Bot/TelegramBotClient.cs
@@ -841,16 +841,21 @@ namespace Telegram.Bot
         /// <param name="chatId"><see cref="ChatId"/> for the target group</param>
         /// <param name="userId">Unique identifier of the target user</param>
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <param name="untilDate">Date when the user will be unbanned, unix time. If user is banned for more than 366 days or less than 30 seconds from the current time they are considered to be banned forever</param>
         /// <returns><c>true</c> on success.</returns>
         /// <see href="https://core.telegram.org/bots/api#kickchatmember"/>
         public Task<bool> KickChatMemberAsync(ChatId chatId, int userId,
-            CancellationToken cancellationToken = default(CancellationToken))
+            CancellationToken cancellationToken = default(CancellationToken),
+            int untilDate = 0)
         {
             var parameters = new Dictionary<string, object>
             {
                 {"chat_id", chatId},
                 {"user_id", userId}
             };
+
+            if (untilDate != 0)
+                parameters.Add("until_date", untilDate);
 
             return SendWebRequestAsync<bool>("kickChatMember", parameters, cancellationToken);
         }
@@ -1005,6 +1010,92 @@ namespace Telegram.Bot
                 parameters.Add("cache_time", cacheTime);
 
             return SendWebRequestAsync<bool>("answerCallbackQuery", parameters, cancellationToken);
+        }
+
+        /// <summary>
+        /// Use this method to restrict a user in a supergroup. The bot must be an administrator in the supergroup for this to work and must have the appropriate admin rights.
+        /// </summary>
+        /// <param name="chatId">Unique identifier for the target chat or username of the target supergroup</param>
+        /// <param name="userId">Unique identifier of the target user</param>
+        /// <param name="untilDate">Date when restrictions will be lifted for the user, unix time. If user is restricted for more than 366 days or less than 30 seconds from the current time, they are considered to be restricted forever</param>
+        /// <param name="canSendMessages">Pass True, if the user can send text messages, contacts, locations and venues</param>
+        /// <param name="canSendMediaMessages">Pass True, if the user can send audios, documents, photos, videos, video notes and voice notes, implies can_send_messages</param>
+        /// <param name="canSendOtherMessages">Pass True, if the user can send animations, games, stickers and use inline bots, implies can_send_media_messages</param>
+        /// <param name="canAddWebPagePreviews">Pass True, if the user may add web page previews to their messages, implies can_send_media_messages</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <returns>On success, <c>true</c> is returned</returns>
+        /// <remarks>Pass True for all boolean parameters to lift restrictions from a user.</remarks>
+        public Task<bool> RestrictChatMemberAsync(ChatId chatId, int userId, int untilDate = 0,
+            bool? canSendMessages = null, bool? canSendMediaMessages = null, bool? canSendOtherMessages = null,
+            bool? canAddWebPagePreviews = null, 
+            CancellationToken cancellationToken = default(CancellationToken))
+        {
+            var parameters = new Dictionary<string, object>()
+            {
+                { "chat_id", chatId },
+                { "user_id", userId }
+            };
+
+            if (untilDate != 0)
+                parameters.Add("until_date", untilDate);
+
+            if (canSendMessages != null)
+                parameters.Add("can_send_messages", canSendMessages.Value);
+            if (canSendMediaMessages != null)
+                parameters.Add("can_send_media_messages", canSendMediaMessages.Value);
+            if (canSendOtherMessages != null)
+                parameters.Add("can_send_other_messages", canSendOtherMessages.Value);
+            if (canAddWebPagePreviews != null)
+                parameters.Add("can_add_web_page_previews", canAddWebPagePreviews.Value);
+
+            return SendWebRequestAsync<bool>("restrictChatMember", parameters, cancellationToken);
+        }
+
+        /// <summary>
+        /// Use this method to promote or demote a user in a supergroup or a channel. The bot must be an administrator in the chat for this to work and must have the appropriate admin rights.
+        /// </summary>
+        /// <param name="chatId">Unique identifier for the target chat or username of the target channel</param>
+        /// <param name="userId">Unique identifier of the target user</param>
+        /// <param name="canChangeInfo">Pass True, if the administrator can change chat title, photo and other settings</param>
+        /// <param name="canPostMessages">Pass True, if the administrator can create channel posts, channels only</param>
+        /// <param name="canEditMessages">Pass True, if the administrator can edit messages of other users, channels only</param>
+        /// <param name="canDeleteMessages">Pass True, if the administrator can delete messages of other users</param>
+        /// <param name="canInviteUsers">Pass True, if the administrator can invite new users to the chat</param>
+        /// <param name="canRestrictMembers">Pass True, if the administrator can restrict, ban or unban chat members</param>
+        /// <param name="canPinMessages">Pass True, if the administrator can pin messages, supergroups only</param>
+        /// <param name="canPromoteMembers">Pass True, if the administrator can add new administrators with a subset of his own privileges or demote administrators that he has promoted, directly or indirectly (promoted by administrators that were appointed by him)</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <returns>Returns True on success.</returns>
+        /// <remarks>Pass False for all boolean parameters to demote a user.</remarks>
+        public Task<bool> PromoteChatMemberAsync(ChatId chatId, int userId, bool? canChangeInfo = null,
+            bool? canPostMessages = null, bool? canEditMessages = null, bool? canDeleteMessages = null,
+            bool? canInviteUsers = null, bool? canRestrictMembers = null, bool? canPinMessages = null,
+            bool? canPromoteMembers = null, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            var parameters = new Dictionary<string, object>()
+            {
+                { "chat_id", chatId },
+                { "user_id", userId }
+            };
+
+            if (canChangeInfo != null)
+                parameters.Add("can_change_info", canChangeInfo.Value);
+            if (canPostMessages != null)
+                parameters.Add("can_post_messages", canPostMessages.Value);
+            if (canEditMessages != null)
+                parameters.Add("can_edit_messages", canEditMessages.Value);
+            if (canDeleteMessages != null)
+                parameters.Add("can_delete_messages", canDeleteMessages.Value);
+            if (canInviteUsers != null)
+                parameters.Add("can_invite_users", canInviteUsers.Value);
+            if (canRestrictMembers != null)
+                parameters.Add("can_restrict_members", canRestrictMembers.Value);
+            if (canPinMessages != null)
+                parameters.Add("can_pin_messages", canPinMessages.Value);
+            if (canPromoteMembers != null)
+                parameters.Add("can_promote_members", canPromoteMembers.Value);
+
+            return SendWebRequestAsync<bool>("promoteChatMember", parameters, cancellationToken);
         }
 
         #endregion Available methods
@@ -1538,6 +1629,139 @@ namespace Telegram.Bot
         }
 
         #endregion Games
+
+        #region Group and channel management
+        /// <summary>
+        /// Use this method to export an invite link to a supergroup or a channel. The bot must be an administrator in the chat for this to work and must have the appropriate admin rights.
+        /// </summary>
+        /// <param name="chatId">Unique identifier for the target chat or username of the target channel</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <returns>Returns exported invite link as String on success.</returns>
+        public Task<string> ExportChatInviteLinkAsync(ChatId chatId, 
+            CancellationToken cancellationToken = default(CancellationToken))
+        {
+            var parameters = new Dictionary<string, object>()
+            {
+                { "chat_id", chatId }
+            };
+
+            return SendWebRequestAsync<string>("exportChatInviteLink", parameters, cancellationToken);
+        }
+
+        /// <summary>
+        /// Use this method to set a new profile photo for the chat. Photos can't be changed for private chats. The bot must be an administrator in the chat for this to work and must have the appropriate admin rights.
+        /// </summary>
+        /// <param name="chatId">Unique identifier for the target chat or username of the target channel</param>
+        /// <param name="photo">The new profile picture for the chat.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <returns>Returns <c>true</c> on success.</returns>
+        public Task<bool> SetChatPhotoAsync(ChatId chatId, FileToSend photo,
+            CancellationToken cancellationToken = default(CancellationToken))
+        {
+            var parameters = new Dictionary<string, object>()
+            {
+                { "chat_id", chatId },
+                { "photo", photo }
+            };
+
+            return SendWebRequestAsync<bool>("setChatPhoto", parameters, cancellationToken);
+        }
+
+        /// <summary>
+        /// Use this method to delete a chat photo. Photos can't be changed for private chats. The bot must be an administrator in the chat for this to work and must have the appropriate admin rights.
+        /// </summary>
+        /// <param name="chatId">Unique identifier for the target chat or username of the target channel</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <returns>Returns true on success.</returns>
+        public Task<bool> DeleteChatPhotoAsync(ChatId chatId, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            var parameters = new Dictionary<string, object>()
+            {
+                { "chat_id", chatId }
+            };
+
+            return SendWebRequestAsync<bool>("deleteChatPhoto", parameters, cancellationToken);
+        }
+
+        /// <summary>
+        /// Use this method to change the title of a chat. Titles can't be changed for private chats. The bot must be an administrator in the chat for this to work and must have the appropriate admin rights.
+        /// </summary>
+        /// <param name="chatId">Unique identifier for the target chat or username of the target channel</param>
+        /// <param name="title">New chat title, 1-255 characters</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <returns>Returns true on success.</returns>
+        public Task<bool> SetChatTitleAsync(ChatId chatId, string title,
+            CancellationToken cancellationToken = default(CancellationToken))
+        {
+            var parameters = new Dictionary<string, object>()
+            {
+                { "chat_id", chatId },
+                { "title", title }
+            };
+
+            return SendWebRequestAsync<bool>("setChatTitle", parameters, cancellationToken);
+        }
+
+        /// <summary>
+        /// Use this method to change the description of a supergroup or a channel. The bot must be an administrator in the chat for this to work and must have the appropriate admin rights.
+        /// </summary>
+        /// <param name="chatId">Unique identifier for the target chat or username of the target channel</param>
+        /// <param name="description">New chat description, 0-255 characters</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <returns>Returns true on success.</returns>
+        public Task<bool> SetChatDescriptionAsync(ChatId chatId, string description = "",
+            CancellationToken cancellationToken = default(CancellationToken))
+        {
+            var parameters = new Dictionary<string, object>()
+            {
+                { "chat_id", chatId }
+            };
+
+            if (!string.IsNullOrEmpty(description))
+                parameters.Add("description", description);
+
+            return SendWebRequestAsync<bool>("setChatDescription", parameters, cancellationToken);
+        }
+
+        /// <summary>
+        /// Use this method to pin a message in a supergroup. The bot must be an administrator in the chat for this to work and must have the appropriate admin rights.
+        /// </summary>
+        /// <param name="chatId">Unique identifier for the target chat or username of the target supergroup</param>
+        /// <param name="messageId">Identifier of a message to pin</param>
+        /// <param name="disableNotification">Pass True, if it is not necessary to send a notification to all group members about the new pinned message</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <returns>Returns true on success.</returns>
+        public Task<bool> PinChatMessageAsync(ChatId chatId, int messageId, bool disableNotification = false,
+            CancellationToken cancellationToken = default(CancellationToken))
+        {
+            var parameters = new Dictionary<string, object>()
+            {
+                { "chat_id", chatId },
+                { "message_id", messageId }
+            };
+
+            if (disableNotification)
+                parameters.Add("disable_notification", disableNotification);
+
+            return SendWebRequestAsync<bool>("pinChatMessage", parameters, cancellationToken);
+        }
+
+        /// <summary>
+        /// Use this method to unpin a message in a supergroup chat. The bot must be an administrator in the chat for this to work and must have the appropriate admin rights.
+        /// </summary>
+        /// <param name="chatId">Unique identifier for the target chat or username of the target supergroup</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <returns>Returns true on success</returns>
+        public Task<bool> UnpinChatMessageAsync(ChatId chatId, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            var parameters = new Dictionary<string, object>()
+            {
+                { "chat_id", chatId }
+            };
+
+            return SendWebRequestAsync<bool>("unpinChatMessage", parameters, cancellationToken);
+        }
+        #endregion
 
         #region Support Methods - Private
 

--- a/src/Telegram.Bot/Types/CallbackQuery.cs
+++ b/src/Telegram.Bot/Types/CallbackQuery.cs
@@ -44,7 +44,7 @@ namespace Telegram.Bot.Types
         /// <remarks>
         /// Be aware that a bad client can send arbitrary data in this field.
         /// </remarks>
-        [JsonProperty("data", Required = Required.Always)]
+        [JsonProperty("data", Required = Required.Default)]
         public string Data { get; set; }
 
         /// <summary>

--- a/src/Telegram.Bot/Types/Chat.cs
+++ b/src/Telegram.Bot/Types/Chat.cs
@@ -50,5 +50,23 @@ namespace Telegram.Bot.Types
         /// </summary>
         [JsonProperty(PropertyName = "all_members_are_administrators", Required = Required.Default)]
         public bool AllMembersAreAdministrators { get; set; }
+
+        /// <summary>
+        /// Optional. Chat photo. Returned only in getChat.
+        /// </summary>
+        [JsonProperty(PropertyName = "photo", Required = Required.Default)]
+        public ChatPhoto Photo { get; set; }
+
+        /// <summary>
+        /// Optional. Description, for supergroups and channel chats. Returned only in getChat.
+        /// </summary>
+        [JsonProperty(PropertyName = "description", Required = Required.Default)]
+        public string Description { get; set; }
+
+        /// <summary>
+        /// Optional. Chat invite link, for supergroups and channel chats. Returned only in getChat.
+        /// </summary>
+        [JsonProperty(PropertyName = "invite_link", Required = Required.Default)]
+        public string InviteLink { get; set; }
     }
 }

--- a/src/Telegram.Bot/Types/ChatMember.cs
+++ b/src/Telegram.Bot/Types/ChatMember.cs
@@ -20,5 +20,89 @@ namespace Telegram.Bot.Types
         /// </summary>
         [JsonProperty("status", Required = Required.Always)]
         public ChatMemberStatus Status { get; set; }
+
+        /// <summary>
+        /// Optional. Restictred and kicked only. Date when restrictions will be lifted for this user, unix time
+        /// </summary>
+        [JsonProperty(PropertyName = "until_date", Required = Required.Default)]
+        public int UntilDate { get; set; }
+
+        /// <summary>
+        /// Optional. Administrators only. True, if the bot is allowed to edit administrator privileges of that user
+        /// </summary>
+        [JsonProperty(PropertyName = "can_be_edited", Required = Required.Default)]
+        public bool CanBeEdited { get; set; }
+
+        /// <summary>
+        /// Optional. Administrators only. True, if the administrator can change the chat title, photo and other settings
+        /// </summary>
+        [JsonProperty(PropertyName = "can_change_info", Required = Required.Default)]
+        public bool CanChangeInfo { get; set; }
+
+        /// <summary>
+        /// Optional. Administrators only. True, if the administrator can post in the channel, channels only
+        /// </summary>
+        [JsonProperty(PropertyName = "can_post_messages", Required = Required.Default)]
+        public bool CanPostMessages { get; set; }
+
+        /// <summary>
+        /// Optional. Administrators only. True, if the administrator can edit messages of other users, channels only
+        /// </summary>
+        [JsonProperty(PropertyName = "can_edit_messages", Required = Required.Default)]
+        public bool CanEditMessages { get; set; }
+
+        /// <summary>
+        /// Optional. Administrators only. True, if the administrator can delete messages of other users
+        /// </summary>
+        [JsonProperty(PropertyName = "can_delete_messages", Required = Required.Default)]
+        public bool CanDeleteMessages { get; set; }
+
+        /// <summary>
+        /// Optional. Administrators only. True, if the administrator can invite new users to the chat
+        /// </summary>
+        [JsonProperty(PropertyName = "can_invite_users", Required = Required.Default)]
+        public bool CanInviteUsers { get; set; }
+
+        /// <summary>
+        /// Optional. Administrators only. True, if the administrator can restrict, ban or unban chat members
+        /// </summary>
+        [JsonProperty(PropertyName = "can_restrict_members", Required = Required.Default)]
+        public bool CanRestrictMembers { get; set; }
+
+        /// <summary>
+        /// Optional. Administrators only. True, if the administrator can pin messages, supergroups only
+        /// </summary>
+        [JsonProperty(PropertyName = "can_pin_messages", Required = Required.Default)]
+        public bool CanPinMessages { get; set; }
+
+        /// <summary>
+        /// Optional. Administrators only. True, if the administrator can add new administrators with a subset of his own privileges or demote administrators that he has promoted, directly or indirectly (promoted by administrators that were appointed by the user)
+        /// </summary>
+        [JsonProperty(PropertyName = "can_promote_members", Required = Required.Default)]
+        public bool CanPromoteMembers { get; set; }
+
+        /// <summary>
+        /// Optional. Restricted only. True, if the user can send text messages, contacts, locations and venues
+        /// </summary>
+        [JsonProperty(PropertyName = "can_send_messages", Required = Required.Default)]
+        public bool CanSendMessages { get; set; }
+
+        /// <summary>
+        /// Optional. Restricted only. True, if the user can send audios, documents, photos, videos, video notes and voice notes, implies <see cref="CanSendMessages"/>
+        /// </summary>
+        [JsonProperty(PropertyName = "can_send_media_messages", Required = Required.Default)]
+        public bool CanSendMediaMessages { get; set; }
+
+        /// <summary>
+        /// Optional. Restricted only. True, if the user can send animations, games, stickers and use inline bots, implies <see cref="CanSendMediaMessages"/>
+        /// </summary>
+        [JsonProperty(PropertyName = "can_send_other_messages", Required = Required.Default)]
+        public bool CanSendOtherMessages { get; set; }
+
+        /// <summary>
+        /// Optional. Restricted only. True, if user may add web page previews to his messages, implies <see cref="CanSendMediaMessages"/>
+        /// </summary>
+        [JsonProperty(PropertyName = "can_add_web_page_previews", Required = Required.Default)]
+        public bool CanAddWebPagePreviews { get; set; }
     }
 }

--- a/src/Telegram.Bot/Types/ChatPhoto.cs
+++ b/src/Telegram.Bot/Types/ChatPhoto.cs
@@ -1,0 +1,25 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Telegram.Bot.Types
+{
+    /// <summary>
+    /// Collection of fileIds of profile pictures of a chat.
+    /// </summary>
+    [JsonObject(MemberSerialization.OptIn)]
+    public class ChatPhoto
+    {
+        /// <summary>
+        /// File id of the big version of this <see cref="ChatPhoto"/>
+        /// </summary>
+        [JsonProperty(PropertyName = "big_file_id", Required = Required.Default)]
+        public string BigFileId { get; set; }
+        /// <summary>
+        /// File id of the small version of this <see cref="ChatPhoto"/>
+        /// </summary>
+        [JsonProperty(PropertyName = "small_file_id", Required = Required.Default)]
+        public string SmallFileId { get; set; }
+    }
+}


### PR DESCRIPTION
This is a quick fix that ignores json serialization exceptions for that specific request method.

In addition to that, 
- `Newtonsoft.Json` package is updated(minor update)
- last few commits from `master` are also merged