### PR TITLE
Fix #385

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,35 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## [12.0.0] - Upcomming
+## [13.0.0] - Currently in Beta
+### Added
+- Method `KickChatMemberAsync` parameter `untilDate`
+- Method `RestrictChatMemberAsync`
+- Method `PromoteChatMemberAsync`
+- Method `ExportChatInviteLinkAsync`
+- Method `SetChatPhotoAsync`
+- Method `DeleteChatPhotoAsync`
+- Method `SetChatTitleAsync`
+- Method `SetChatDescriptionAsync`
+- Method `PinChatMessageAsync`
+- Method `UnpinChatMessageAsync`
+- Method `SendVideoNoteAsync` parameter `length`
+- Type `VideoNote` property `Length`
+- Type `Chat`properties `Photo`, `Description`, `InviteLink`
+- Type `ChatMember` properties `UntilDate`, `Can*`
+- Type `ChatPhoto` 
+
+### Changed
+- User and Chat Ids reverted to base types
+- DateTimes are now in local time zone
+
+### Fix
+- Inline messge editing
+- Method `SetWebHookAsync` parameter `max_connections`
+- Type `CallbackQuery` Property `Data` optimal 
+- Type `Message` can now be a `VideoNoteMessage`
+
+## [12.0.0] - Beta only
 ### Added
 - Method `DeleteMessageAsync`
 - Method `SendVideoNoteAsync`

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Before submitting issues please consult following resources:
 * [Library docs](https://mrroundrobin.github.io/telegram.bot/)
 * [Changelog](https://github.com/MrRoundRobin/telegram.bot/blob/master/CHANGELOG.md)
 * [API docs](https://core.telegram.org/bots/api)
-* [Webook docs](https://core.telegram.org/bots/webhooks)
+* [Webhook docs](https://core.telegram.org/bots/webhooks)
 * [Examples](https://github.com/MrRoundRobin/telegram.bot.examples)
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -39,10 +39,10 @@ For testing you can use the [MyGet feed](https://www.myget.org/gallery/telegram-
 ## API Coverage
 
 * [Inline Mode](https://core.telegram.org/bots/inline)
-* [Bot API 3.0](https://core.telegram.org/bots/api-changelog)
+* [Bot API 3.1](https://core.telegram.org/bots/api-changelog)
 * [Payments](https://core.telegram.org/bots/payments) (Needs some testing)
 * [Games](https://core.telegram.org/bots/games)
 
-Missing / TODO (last check 07.06.2017):
+Missing / TODO (last check 13.07.2017):
 
 * [Making requests when getting updates](https://core.telegram.org/bots/api#making-requests-when-getting-updates)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 12.0.0-ci-{build}
+version: 13.0.0-ci-{build}
 pull_requests:
   do_not_increment_build_number: true
 branches:

--- a/src/Telegram.Bot/Converters/ParseModeConverter.cs
+++ b/src/Telegram.Bot/Converters/ParseModeConverter.cs
@@ -12,9 +12,10 @@ namespace Telegram.Bot.Converters
         
 
         public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
-            =>ParseModeExtensions.StringMap.FirstOrDefault(mode => mode.Value == reader.ReadAsString());
+            => ParseModeExtensions.StringMap.FirstOrDefault(mode => mode.Value == reader.ReadAsString());
         
 
-        public override bool CanConvert(Type objectType) => objectType == typeof (ParseMode);
+        public override bool CanConvert(Type objectType)
+            => objectType == typeof (ParseMode);
     }
 }

--- a/src/Telegram.Bot/Converters/UnixDatetimeConverter.cs
+++ b/src/Telegram.Bot/Converters/UnixDatetimeConverter.cs
@@ -3,9 +3,7 @@ using System;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
 
-#if !NET46
 using Telegram.Bot.Helpers;
-#endif
 
 namespace Telegram.Bot.Converters
 {
@@ -28,11 +26,7 @@ namespace Telegram.Bot.Converters
             long val;
             if (value is DateTime || value is Nullable<DateTime>)
             {
-#if NET46
-                val = new DateTimeOffset((DateTime)value).ToUnixTimeSeconds();
-#else
                 val = ((DateTime)value).ToUnixTime();
-#endif
             }
             else
             {
@@ -66,11 +60,7 @@ namespace Telegram.Bot.Converters
 
             var ticks = (long)reader.Value;
 
-#if NET46
-            return DateTimeOffset.FromUnixTimeSeconds(ticks).DateTime;
-#else
             return ticks.FromUnixTime();
-#endif
         }
 
         /// <summary>

--- a/src/Telegram.Bot/Helpers/Extensions.cs
+++ b/src/Telegram.Bot/Helpers/Extensions.cs
@@ -1,4 +1,3 @@
-#if !NET46
 using System;
 
 namespace Telegram.Bot.Helpers
@@ -14,15 +13,18 @@ namespace Telegram.Bot.Helpers
         ///   Convert a long into a DateTime
         /// </summary>
         public static DateTime FromUnixTime(this long dateTime) 
-            => UnixStart.AddSeconds(dateTime);
+            => UnixStart.AddSeconds(dateTime).ToLocalTime();
 
         /// <summary>
         ///   Convert a DateTime into a long
         /// </summary>
         /// <exception cref="ArgumentOutOfRangeException"></exception>
+        /// <exception cref="OverflowException"></exception>
         public static long ToUnixTime(this DateTime dateTime)
         {
-            if (dateTime == DateTime.MinValue)
+            var utcDateTime = dateTime.ToUniversalTime();
+
+            if (utcDateTime == DateTime.MinValue)
                 return 0;
 
             var delta = dateTime - UnixStart;
@@ -30,9 +32,7 @@ namespace Telegram.Bot.Helpers
             if (delta.TotalSeconds < 0)
                 throw new ArgumentOutOfRangeException(nameof(dateTime), "Unix epoc starts January 1st, 1970");
 
-            return (long)delta.TotalSeconds;
+            return Convert.ToInt64(delta.TotalSeconds);
         }
     }
 }
-
-#endif

--- a/src/Telegram.Bot/ITelegramBotClient.cs
+++ b/src/Telegram.Bot/ITelegramBotClient.cs
@@ -363,6 +363,7 @@ namespace Telegram.Bot
         /// <param name="chatId"><see cref="ChatId"/> for the target chat</param>
         /// <param name="videoNote">Video note to send.</param>
         /// <param name="duration">Duration of sent video in seconds</param>
+        /// <param name="length">Video width and height</param>
         /// <param name="disableNotification">Sends the message silently. iOS users will not receive a notification, Android users will receive a notification with no sound.</param>
         /// <param name="replyToMessageId">If the message is a reply, ID of the original message</param>
         /// <param name="replyMarkup">Additional interface options. A JSON-serialized object for a custom reply keyboard, instructions to hide keyboard or to force a reply from the user.</param>
@@ -371,6 +372,7 @@ namespace Telegram.Bot
         /// <see href="https://core.telegram.org/bots/api#sendvideonote"/>
         Task<Message> SendVideoNoteAsync(ChatId chatId, FileToSend videoNote,
             int duration = 0,
+            int length = 0,
             bool disableNotification = false,
             int replyToMessageId = 0,
             IReplyMarkup replyMarkup = null,

--- a/src/Telegram.Bot/ITelegramBotClient.cs
+++ b/src/Telegram.Bot/ITelegramBotClient.cs
@@ -476,10 +476,11 @@ namespace Telegram.Bot
         /// </summary>
         /// <param name="chatId"><see cref="ChatId"/> for the target group</param>
         /// <param name="userId">Unique identifier of the target user</param>
+        /// <param name="untilDate"><see cref="DateTime"/> when the user will be unbanned. If user is banned for more than 366 days or less than 30 seconds from the current time they are considered to be banned forever</param>
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <returns><c>true</c> on success.</returns>
         /// <see href="https://core.telegram.org/bots/api#kickchatmember"/>
-        Task<bool> KickChatMemberAsync(ChatId chatId, int userId,
+        Task<bool> KickChatMemberAsync(ChatId chatId, int userId, DateTime untilDate = default(DateTime),
             CancellationToken cancellationToken = default(CancellationToken));
 
         /// <summary>
@@ -565,6 +566,47 @@ namespace Telegram.Bot
             string url = null,
             int cacheTime = 0,
             CancellationToken cancellationToken = default(CancellationToken));
+
+        /// <summary>
+        /// Use this method to restrict a user in a supergroup. The bot must be an administrator in the supergroup for this to work and must have the appropriate admin rights.
+        /// </summary>
+        /// <param name="chatId">Unique identifier for the target chat or username of the target supergroup</param>
+        /// <param name="userId">Unique identifier of the target user</param>
+        /// <param name="untilDate"><see cref="DateTime"/> when restrictions will be lifted for the user. If user is restricted for more than 366 days or less than 30 seconds from the current time, they are considered to be restricted forever</param>
+        /// <param name="canSendMessages">Pass True, if the user can send text messages, contacts, locations and venues</param>
+        /// <param name="canSendMediaMessages">Pass True, if the user can send audios, documents, photos, videos, video notes and voice notes, implies can_send_messages</param>
+        /// <param name="canSendOtherMessages">Pass True, if the user can send animations, games, stickers and use inline bots, implies can_send_media_messages</param>
+        /// <param name="canAddWebPagePreviews">Pass True, if the user may add web page previews to their messages, implies can_send_media_messages</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <returns>On success, <c>true</c> is returned</returns>
+        /// <remarks>Pass True for all boolean parameters to lift restrictions from a user.</remarks>
+        /// <see href="https://core.telegram.org/bots/api#restrictchatmember"/>
+        Task<bool> RestrictChatMemberAsync(ChatId chatId, int userId, DateTime untilDate = default(DateTime),
+            bool? canSendMessages = null, bool? canSendMediaMessages = null, bool? canSendOtherMessages = null,
+            bool? canAddWebPagePreviews = null,
+            CancellationToken cancellationToken = default(CancellationToken));
+
+        /// <summary>
+        /// Use this method to promote or demote a user in a supergroup or a channel. The bot must be an administrator in the chat for this to work and must have the appropriate admin rights.
+        /// </summary>
+        /// <param name="chatId">Unique identifier for the target chat or username of the target channel</param>
+        /// <param name="userId">Unique identifier of the target user</param>
+        /// <param name="canChangeInfo">Pass True, if the administrator can change chat title, photo and other settings</param>
+        /// <param name="canPostMessages">Pass True, if the administrator can create channel posts, channels only</param>
+        /// <param name="canEditMessages">Pass True, if the administrator can edit messages of other users, channels only</param>
+        /// <param name="canDeleteMessages">Pass True, if the administrator can delete messages of other users</param>
+        /// <param name="canInviteUsers">Pass True, if the administrator can invite new users to the chat</param>
+        /// <param name="canRestrictMembers">Pass True, if the administrator can restrict, ban or unban chat members</param>
+        /// <param name="canPinMessages">Pass True, if the administrator can pin messages, supergroups only</param>
+        /// <param name="canPromoteMembers">Pass True, if the administrator can add new administrators with a subset of his own privileges or demote administrators that he has promoted, directly or indirectly (promoted by administrators that were appointed by him)</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <returns>Returns True on success.</returns>
+        /// <remarks>Pass False for all boolean parameters to demote a user.</remarks>
+        /// <see href="https://core.telegram.org/bots/api#promotechatmember"/>
+        Task<bool> PromoteChatMemberAsync(ChatId chatId, int userId, bool? canChangeInfo = null,
+            bool? canPostMessages = null, bool? canEditMessages = null, bool? canDeleteMessages = null,
+            bool? canInviteUsers = null, bool? canRestrictMembers = null, bool? canPinMessages = null,
+            bool? canPromoteMembers = null, CancellationToken cancellationToken = default(CancellationToken));
 
         #endregion Available methods
 
@@ -858,5 +900,82 @@ namespace Telegram.Bot
         Task<GameHighScore[]> GetGameHighScoresAsync(int userId, string inlineMessageId, CancellationToken cancellationToken = default(CancellationToken));
 
         #endregion Games
+
+        #region Group and channel management
+        /// <summary>
+        /// Use this method to export an invite link to a supergroup or a channel. The bot must be an administrator in the chat for this to work and must have the appropriate admin rights.
+        /// </summary>
+        /// <param name="chatId">Unique identifier for the target chat or username of the target channel</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <returns>Returns exported invite link as String on success.</returns>
+        /// <see href="https://core.telegram.org/bots/api#exportchatinvitelink"/>
+        Task<string> ExportChatInviteLinkAsync(ChatId chatId,
+            CancellationToken cancellationToken = default(CancellationToken));
+
+        /// <summary>
+        /// Use this method to set a new profile photo for the chat. Photos can't be changed for private chats. The bot must be an administrator in the chat for this to work and must have the appropriate admin rights.
+        /// </summary>
+        /// <param name="chatId">Unique identifier for the target chat or username of the target channel</param>
+        /// <param name="photo">The new profile picture for the chat.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <returns>Returns <c>true</c> on success.</returns>
+        /// <see href="https://core.telegram.org/bots/api#setchatphoto"/>
+        Task<bool> SetChatPhotoAsync(ChatId chatId, FileToSend photo, 
+            CancellationToken cancellationToken = default(CancellationToken));
+
+        /// <summary>
+        /// Use this method to delete a chat photo. Photos can't be changed for private chats. The bot must be an administrator in the chat for this to work and must have the appropriate admin rights.
+        /// </summary>
+        /// <param name="chatId">Unique identifier for the target chat or username of the target channel</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <returns>Returns true on success.</returns>
+        /// <see href="https://core.telegram.org/bots/api#deletechatphoto"/>
+        Task<bool> DeleteChatPhotoAsync(ChatId chatId, CancellationToken cancellationToken = default(CancellationToken));
+
+        /// <summary>
+        /// Use this method to change the title of a chat. Titles can't be changed for private chats. The bot must be an administrator in the chat for this to work and must have the appropriate admin rights.
+        /// </summary>
+        /// <param name="chatId">Unique identifier for the target chat or username of the target channel</param>
+        /// <param name="title">New chat title, 1-255 characters</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <returns>Returns true on success.</returns>
+        /// <see href="https://core.telegram.org/bots/api#setchattitle"/>
+        Task<bool> SetChatTitleAsync(ChatId chatId, string title,
+            CancellationToken cancellationToken = default(CancellationToken));
+
+        /// <summary>
+        /// Use this method to change the description of a supergroup or a channel. The bot must be an administrator in the chat for this to work and must have the appropriate admin rights.
+        /// </summary>
+        /// <param name="chatId">Unique identifier for the target chat or username of the target channel</param>
+        /// <param name="description">New chat description, 0-255 characters. Defaults to an empty string, which would clear the description.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <returns>Returns true on success.</returns>
+        /// <see href="https://core.telegram.org/bots/api#setchatdescription"/>
+        Task<bool> SetChatDescriptionAsync(ChatId chatId, string description = "",
+            CancellationToken cancellationToken = default(CancellationToken));
+
+        /// <summary>
+        /// Use this method to pin a message in a supergroup. The bot must be an administrator in the chat for this to work and must have the appropriate admin rights.
+        /// </summary>
+        /// <param name="chatId">Unique identifier for the target chat or username of the target supergroup</param>
+        /// <param name="messageId">Identifier of a message to pin</param>
+        /// <param name="disableNotification">Pass True, if it is not necessary to send a notification to all group members about the new pinned message</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <returns>Returns true on success.</returns>
+        /// <see href="https://core.telegram.org/bots/api#pinchatmessage"/>
+        Task<bool> PinChatMessageAsync(ChatId chatId, int messageId, bool disableNotification = false,
+            CancellationToken cancellationToken = default(CancellationToken));
+
+        /// <summary>
+        /// Use this method to unpin a message in a supergroup chat. The bot must be an administrator in the chat for this to work and must have the appropriate admin rights.
+        /// </summary>
+        /// <param name="chatId">Unique identifier for the target chat or username of the target supergroup</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <returns>Returns true on success</returns>
+        /// <see href="https://core.telegram.org/bots/api#unpinchatmessage"/>
+        Task<bool> UnpinChatMessageAsync(ChatId chatId, CancellationToken cancellationToken = default(CancellationToken));
+
+
+        #endregion
     }
 }

--- a/src/Telegram.Bot/ITelegramBotClient.cs
+++ b/src/Telegram.Bot/ITelegramBotClient.cs
@@ -23,7 +23,7 @@ namespace Telegram.Bot
         /// Timeout for requests
         /// </summary>
         TimeSpan Timeout { get; set; }
-        
+
         /// <summary>
         /// Indecates if receiving updates
         /// </summary>
@@ -41,7 +41,7 @@ namespace Telegram.Bot
         /// Occurs when an <see cref="Update"/> is received.
         /// </summary>
         event EventHandler<UpdateEventArgs> OnUpdate;
- 
+
         /// <summary>
         /// Occurs when a <see cref="Message"/> is recieved.
         /// </summary>
@@ -349,7 +349,7 @@ namespace Telegram.Bot
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <returns>On success, the sent Message is returned.</returns>
         /// <see href="https://core.telegram.org/bots/api#sendvoice"/>
-        Task<Message> SendVoiceAsync(ChatId chatId, FileToSend voice, 
+        Task<Message> SendVoiceAsync(ChatId chatId, FileToSend voice,
             string caption = "",
             int duration = 0,
             bool disableNotification = false,
@@ -595,9 +595,9 @@ namespace Telegram.Bot
         /// <param name="disableWebPagePreview">Disables link previews for links in this message</param>
         /// <param name="replyMarkup">A JSON-serialized object for an inline keyboard.</param>
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
-        /// <returns>On success, the edited Message is returned.</returns>
+        /// <returns>><c>true</c> on success.</returns>
         /// <see href="https://core.telegram.org/bots/api#editmessagetext"/>
-        Task<Message> EditInlineMessageTextAsync(string inlineMessageId, string text,
+        Task<bool> EditInlineMessageTextAsync(string inlineMessageId, string text,
             ParseMode parseMode = ParseMode.Default,
             bool disableWebPagePreview = false,
             IReplyMarkup replyMarkup = null,
@@ -624,9 +624,9 @@ namespace Telegram.Bot
         /// <param name="caption">New caption of the message</param>
         /// <param name="replyMarkup">A JSON-serialized object for an inline keyboard.</param>
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
-        /// <returns>On success, the edited Message is returned.</returns>
+        /// <returns>><c>true</c> on success.</returns>
         /// <see href="https://core.telegram.org/bots/api#editmessagecaption"/>
-        Task<Message> EditInlineMessageCaptionAsync(string inlineMessageId, string caption,
+        Task<bool> EditInlineMessageCaptionAsync(string inlineMessageId, string caption,
             IReplyMarkup replyMarkup = null,
             CancellationToken cancellationToken = default(CancellationToken));
 
@@ -649,9 +649,9 @@ namespace Telegram.Bot
         /// <param name="inlineMessageId">Unique identifier of the sent message</param>
         /// <param name="replyMarkup">A JSON-serialized object for an inline keyboard.</param>
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
-        /// <returns>On success, the edited Message is returned.</returns>
+        /// <returns>><c>true</c> on success.</returns>
         /// <see href="https://core.telegram.org/bots/api#editmessagereplymarkup"/>
-        Task<Message> EditInlineMessageReplyMarkupAsync(string inlineMessageId,
+        Task<bool> EditInlineMessageReplyMarkupAsync(string inlineMessageId,
             IReplyMarkup replyMarkup = null,
             CancellationToken cancellationToken = default(CancellationToken));
 
@@ -734,7 +734,7 @@ namespace Telegram.Bot
             bool needName = false,
             bool needPhoneNumber = false,
             bool needEmail = false,
-            bool needShippingAddress= false,
+            bool needShippingAddress = false,
             bool isFlexible = false,
             bool disableNotification = false,
             int replyToMessageId = 0,

--- a/src/Telegram.Bot/Telegram.Bot.csproj
+++ b/src/Telegram.Bot/Telegram.Bot.csproj
@@ -25,7 +25,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="10.0.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
   </ItemGroup>
 
 </Project>

--- a/src/Telegram.Bot/TelegramBotClient.cs
+++ b/src/Telegram.Bot/TelegramBotClient.cs
@@ -165,7 +165,7 @@ namespace Telegram.Bot
             _token = token;
             _httpClient = httpClient ?? new HttpClient();
         }
-
+        
         /// <summary>
         /// Create a new <see cref="TelegramBotClient"/> instance behind a proxy.
         /// </summary>
@@ -186,8 +186,7 @@ namespace Telegram.Bot
             _token = token;
             _httpClient = new HttpClient(httpClientHander);
         }
-
-
+        
         #region Helpers
 
         /// <summary>
@@ -859,17 +858,22 @@ namespace Telegram.Bot
         /// </summary>
         /// <param name="chatId"><see cref="ChatId"/> for the target group</param>
         /// <param name="userId">Unique identifier of the target user</param>
+        /// <param name="untilDate"><see cref="DateTime"/> when the user will be unbanned. If user is banned for more than 366 days or less than 30 seconds from the current time they are considered to be banned forever</param>
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <returns><c>true</c> on success.</returns>
         /// <see href="https://core.telegram.org/bots/api#kickchatmember"/>
         public Task<bool> KickChatMemberAsync(ChatId chatId, int userId,
+            DateTime untilDate = default(DateTime),
             CancellationToken cancellationToken = default(CancellationToken))
         {
             var parameters = new Dictionary<string, object>
             {
                 {"chat_id", chatId},
-                {"user_id", userId}
+                {"user_id", userId},
             };
+
+            if (untilDate != default(DateTime))
+                parameters.Add("until_date", untilDate);
 
             return SendWebRequestAsync<bool>("kickChatMember", parameters, cancellationToken);
         }
@@ -1024,6 +1028,94 @@ namespace Telegram.Bot
                 parameters.Add("cache_time", cacheTime);
 
             return SendWebRequestAsync<bool>("answerCallbackQuery", parameters, cancellationToken);
+        }
+
+        /// <summary>
+        /// Use this method to restrict a user in a supergroup. The bot must be an administrator in the supergroup for this to work and must have the appropriate admin rights.
+        /// </summary>
+        /// <param name="chatId">Unique identifier for the target chat or username of the target supergroup</param>
+        /// <param name="userId">Unique identifier of the target user</param>
+        /// <param name="untilDate"><see cref="DateTime"/> when restrictions will be lifted for the user. If user is restricted for more than 366 days or less than 30 seconds from the current time, they are considered to be restricted forever</param>
+        /// <param name="canSendMessages">Pass True, if the user can send text messages, contacts, locations and venues</param>
+        /// <param name="canSendMediaMessages">Pass True, if the user can send audios, documents, photos, videos, video notes and voice notes, implies can_send_messages</param>
+        /// <param name="canSendOtherMessages">Pass True, if the user can send animations, games, stickers and use inline bots, implies can_send_media_messages</param>
+        /// <param name="canAddWebPagePreviews">Pass True, if the user may add web page previews to their messages, implies can_send_media_messages</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <returns>On success, <c>true</c> is returned</returns>
+        /// <remarks>Pass True for all boolean parameters to lift restrictions from a user.</remarks>
+        /// <see href="https://core.telegram.org/bots/api#restrictchatmember"/>
+        public Task<bool> RestrictChatMemberAsync(ChatId chatId, int userId, DateTime untilDate = default(DateTime),
+            bool? canSendMessages = null, bool? canSendMediaMessages = null, bool? canSendOtherMessages = null,
+            bool? canAddWebPagePreviews = null, 
+            CancellationToken cancellationToken = default(CancellationToken))
+        {
+            var parameters = new Dictionary<string, object>()
+            {
+                { "chat_id", chatId },
+                { "user_id", userId }
+            };
+
+            if (untilDate != default(DateTime))
+                parameters.Add("until_date", untilDate);
+
+            if (canSendMessages != null)
+                parameters.Add("can_send_messages", canSendMessages.Value);
+            if (canSendMediaMessages != null)
+                parameters.Add("can_send_media_messages", canSendMediaMessages.Value);
+            if (canSendOtherMessages != null)
+                parameters.Add("can_send_other_messages", canSendOtherMessages.Value);
+            if (canAddWebPagePreviews != null)
+                parameters.Add("can_add_web_page_previews", canAddWebPagePreviews.Value);
+
+            return SendWebRequestAsync<bool>("restrictChatMember", parameters, cancellationToken);
+        }
+
+        /// <summary>
+        /// Use this method to promote or demote a user in a supergroup or a channel. The bot must be an administrator in the chat for this to work and must have the appropriate admin rights.
+        /// </summary>
+        /// <param name="chatId">Unique identifier for the target chat or username of the target channel</param>
+        /// <param name="userId">Unique identifier of the target user</param>
+        /// <param name="canChangeInfo">Pass True, if the administrator can change chat title, photo and other settings</param>
+        /// <param name="canPostMessages">Pass True, if the administrator can create channel posts, channels only</param>
+        /// <param name="canEditMessages">Pass True, if the administrator can edit messages of other users, channels only</param>
+        /// <param name="canDeleteMessages">Pass True, if the administrator can delete messages of other users</param>
+        /// <param name="canInviteUsers">Pass True, if the administrator can invite new users to the chat</param>
+        /// <param name="canRestrictMembers">Pass True, if the administrator can restrict, ban or unban chat members</param>
+        /// <param name="canPinMessages">Pass True, if the administrator can pin messages, supergroups only</param>
+        /// <param name="canPromoteMembers">Pass True, if the administrator can add new administrators with a subset of his own privileges or demote administrators that he has promoted, directly or indirectly (promoted by administrators that were appointed by him)</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <returns>Returns True on success.</returns>
+        /// <remarks>Pass False for all boolean parameters to demote a user.</remarks>
+        /// <see href="https://core.telegram.org/bots/api#promotechatmember"/>
+        public Task<bool> PromoteChatMemberAsync(ChatId chatId, int userId, bool? canChangeInfo = null,
+            bool? canPostMessages = null, bool? canEditMessages = null, bool? canDeleteMessages = null,
+            bool? canInviteUsers = null, bool? canRestrictMembers = null, bool? canPinMessages = null,
+            bool? canPromoteMembers = null, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            var parameters = new Dictionary<string, object>()
+            {
+                { "chat_id", chatId },
+                { "user_id", userId }
+            };
+
+            if (canChangeInfo != null)
+                parameters.Add("can_change_info", canChangeInfo.Value);
+            if (canPostMessages != null)
+                parameters.Add("can_post_messages", canPostMessages.Value);
+            if (canEditMessages != null)
+                parameters.Add("can_edit_messages", canEditMessages.Value);
+            if (canDeleteMessages != null)
+                parameters.Add("can_delete_messages", canDeleteMessages.Value);
+            if (canInviteUsers != null)
+                parameters.Add("can_invite_users", canInviteUsers.Value);
+            if (canRestrictMembers != null)
+                parameters.Add("can_restrict_members", canRestrictMembers.Value);
+            if (canPinMessages != null)
+                parameters.Add("can_pin_messages", canPinMessages.Value);
+            if (canPromoteMembers != null)
+                parameters.Add("can_promote_members", canPromoteMembers.Value);
+
+            return SendWebRequestAsync<bool>("promoteChatMember", parameters, cancellationToken);
         }
 
         #endregion Available methods
@@ -1534,6 +1626,146 @@ namespace Telegram.Bot
         }
 
         #endregion Games
+
+        #region Group and channel management
+        /// <summary>
+        /// Use this method to export an invite link to a supergroup or a channel. The bot must be an administrator in the chat for this to work and must have the appropriate admin rights.
+        /// </summary>
+        /// <param name="chatId">Unique identifier for the target chat or username of the target channel</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <returns>Returns exported invite link as String on success.</returns>
+        /// <see href="https://core.telegram.org/bots/api#exportchatinvitelink"/>
+        public Task<string> ExportChatInviteLinkAsync(ChatId chatId, 
+            CancellationToken cancellationToken = default(CancellationToken))
+        {
+            var parameters = new Dictionary<string, object>()
+            {
+                { "chat_id", chatId }
+            };
+
+            return SendWebRequestAsync<string>("exportChatInviteLink", parameters, cancellationToken);
+        }
+
+        /// <summary>
+        /// Use this method to set a new profile photo for the chat. Photos can't be changed for private chats. The bot must be an administrator in the chat for this to work and must have the appropriate admin rights.
+        /// </summary>
+        /// <param name="chatId">Unique identifier for the target chat or username of the target channel</param>
+        /// <param name="photo">The new profile picture for the chat.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <returns>Returns <c>true</c> on success.</returns>
+        /// <see href="https://core.telegram.org/bots/api#setchatphoto"/>
+        public Task<bool> SetChatPhotoAsync(ChatId chatId, FileToSend photo,
+            CancellationToken cancellationToken = default(CancellationToken))
+        {
+            var parameters = new Dictionary<string, object>()
+            {
+                { "chat_id", chatId },
+                { "photo", photo }
+            };
+
+            return SendWebRequestAsync<bool>("setChatPhoto", parameters, cancellationToken);
+        }
+
+        /// <summary>
+        /// Use this method to delete a chat photo. Photos can't be changed for private chats. The bot must be an administrator in the chat for this to work and must have the appropriate admin rights.
+        /// </summary>
+        /// <param name="chatId">Unique identifier for the target chat or username of the target channel</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <returns>Returns true on success.</returns>
+        /// <see href="https://core.telegram.org/bots/api#deletechatphoto"/>
+        public Task<bool> DeleteChatPhotoAsync(ChatId chatId, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            var parameters = new Dictionary<string, object>()
+            {
+                { "chat_id", chatId }
+            };
+
+            return SendWebRequestAsync<bool>("deleteChatPhoto", parameters, cancellationToken);
+        }
+
+        /// <summary>
+        /// Use this method to change the title of a chat. Titles can't be changed for private chats. The bot must be an administrator in the chat for this to work and must have the appropriate admin rights.
+        /// </summary>
+        /// <param name="chatId">Unique identifier for the target chat or username of the target channel</param>
+        /// <param name="title">New chat title, 1-255 characters</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <returns>Returns true on success.</returns>
+        /// <see href="https://core.telegram.org/bots/api#setchattitle"/>
+        public Task<bool> SetChatTitleAsync(ChatId chatId, string title,
+            CancellationToken cancellationToken = default(CancellationToken))
+        {
+            var parameters = new Dictionary<string, object>()
+            {
+                { "chat_id", chatId },
+                { "title", title }
+            };
+
+            return SendWebRequestAsync<bool>("setChatTitle", parameters, cancellationToken);
+        }
+
+        /// <summary>
+        /// Use this method to change the description of a supergroup or a channel. The bot must be an administrator in the chat for this to work and must have the appropriate admin rights.
+        /// </summary>
+        /// <param name="chatId">Unique identifier for the target chat or username of the target channel</param>
+        /// <param name="description">New chat description, 0-255 characters. Defaults to an empty string, which would clear the description.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <returns>Returns true on success.</returns>
+        /// <see href="https://core.telegram.org/bots/api#setchatdescription"/>
+        public Task<bool> SetChatDescriptionAsync(ChatId chatId, string description = "",
+            CancellationToken cancellationToken = default(CancellationToken))
+        {
+            var parameters = new Dictionary<string, object>()
+            {
+                { "chat_id", chatId }
+            };
+
+            if (!string.IsNullOrEmpty(description))
+                parameters.Add("description", description);
+
+            return SendWebRequestAsync<bool>("setChatDescription", parameters, cancellationToken);
+        }
+
+        /// <summary>
+        /// Use this method to pin a message in a supergroup. The bot must be an administrator in the chat for this to work and must have the appropriate admin rights.
+        /// </summary>
+        /// <param name="chatId">Unique identifier for the target chat or username of the target supergroup</param>
+        /// <param name="messageId">Identifier of a message to pin</param>
+        /// <param name="disableNotification">Pass True, if it is not necessary to send a notification to all group members about the new pinned message</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <returns>Returns true on success.</returns>
+        /// <see href="https://core.telegram.org/bots/api#pinchatmessage"/>
+        public Task<bool> PinChatMessageAsync(ChatId chatId, int messageId, bool disableNotification = false,
+            CancellationToken cancellationToken = default(CancellationToken))
+        {
+            var parameters = new Dictionary<string, object>()
+            {
+                { "chat_id", chatId },
+                { "message_id", messageId }
+            };
+
+            if (disableNotification)
+                parameters.Add("disable_notification", disableNotification);
+
+            return SendWebRequestAsync<bool>("pinChatMessage", parameters, cancellationToken);
+        }
+
+        /// <summary>
+        /// Use this method to unpin a message in a supergroup chat. The bot must be an administrator in the chat for this to work and must have the appropriate admin rights.
+        /// </summary>
+        /// <param name="chatId">Unique identifier for the target chat or username of the target supergroup</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <returns>Returns true on success</returns>
+        /// <see href="https://core.telegram.org/bots/api#unpinchatmessage"/>
+        public Task<bool> UnpinChatMessageAsync(ChatId chatId, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            var parameters = new Dictionary<string, object>()
+            {
+                { "chat_id", chatId }
+            };
+
+            return SendWebRequestAsync<bool>("unpinChatMessage", parameters, cancellationToken);
+        }
+        #endregion
 
         #region Support Methods - Private
 

--- a/src/Telegram.Bot/TelegramBotClient.cs
+++ b/src/Telegram.Bot/TelegramBotClient.cs
@@ -1907,7 +1907,7 @@ namespace Telegram.Bot
                 case "FileToSend":
                     return new StreamContent(((FileToSend)value).Content);
                 default:
-                    return new StringContent(JsonConvert.SerializeObject(value, SerializerSettings));
+                    return new StringContent(JsonConvert.SerializeObject(value, SerializerSettings).Trim('"'));
             }
         }
         #endregion

--- a/src/Telegram.Bot/TelegramBotClient.cs
+++ b/src/Telegram.Bot/TelegramBotClient.cs
@@ -1055,9 +1055,9 @@ namespace Telegram.Bot
         /// <param name="disableWebPagePreview">Disables link previews for links in this message</param>
         /// <param name="replyMarkup">A JSON-serialized object for an inline keyboard.</param>
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
-        /// <returns>On success, the edited Message is returned.</returns>
+        /// <returns>><c>true</c> on success.</returns>
         /// <see href="https://core.telegram.org/bots/api#editmessagetext"/>
-        public Task<Message> EditInlineMessageTextAsync(string inlineMessageId, string text,
+        public Task<bool> EditInlineMessageTextAsync(string inlineMessageId, string text,
             ParseMode parseMode = ParseMode.Default,
             bool disableWebPagePreview = false,
             IReplyMarkup replyMarkup = null,
@@ -1076,7 +1076,7 @@ namespace Telegram.Bot
             if (parseMode != ParseMode.Default)
                 parameters.Add("parse_mode", parseMode.ToModeString());
 
-            return SendWebRequestAsync<Message>("editMessageText", parameters, cancellationToken);
+            return SendWebRequestAsync<bool>("editMessageText", parameters, cancellationToken);
         }
 
         /// <summary>
@@ -1113,9 +1113,9 @@ namespace Telegram.Bot
         /// <param name="caption">New caption of the message</param>
         /// <param name="replyMarkup">A JSON-serialized object for an inline keyboard.</param>
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
-        /// <returns>On success, the edited Message is returned.</returns>
+        /// <returns>><c>true</c> on success.</returns>
         /// <see href="https://core.telegram.org/bots/api#editmessagecaption"/>
-        public Task<Message> EditInlineMessageCaptionAsync(string inlineMessageId, string caption,
+        public Task<bool> EditInlineMessageCaptionAsync(string inlineMessageId, string caption,
             IReplyMarkup replyMarkup = null,
             CancellationToken cancellationToken = default(CancellationToken))
         {
@@ -1128,7 +1128,7 @@ namespace Telegram.Bot
             if (replyMarkup != null)
                 parameters.Add("reply_markup", replyMarkup);
 
-            return SendWebRequestAsync<Message>("editMessageCaption", parameters, cancellationToken);
+            return SendWebRequestAsync<bool>("editMessageCaption", parameters, cancellationToken);
         }
 
         /// <summary>
@@ -1162,9 +1162,9 @@ namespace Telegram.Bot
         /// <param name="inlineMessageId">Unique identifier of the sent message</param>
         /// <param name="replyMarkup">A JSON-serialized object for an inline keyboard.</param>
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
-        /// <returns>On success, the edited Message is returned.</returns>
+        /// <returns>><c>true</c> on success.</returns>
         /// <see href="https://core.telegram.org/bots/api#editmessagereplymarkup"/>
-        public Task<Message> EditInlineMessageReplyMarkupAsync(string inlineMessageId,
+        public Task<bool> EditInlineMessageReplyMarkupAsync(string inlineMessageId,
             IReplyMarkup replyMarkup = null,
             CancellationToken cancellationToken = default(CancellationToken))
         {
@@ -1176,7 +1176,7 @@ namespace Telegram.Bot
             if (replyMarkup != null)
                 parameters.Add("reply_markup", replyMarkup);
 
-            return SendWebRequestAsync<Message>("editMessageReplyMarkup", parameters, cancellationToken);
+            return SendWebRequestAsync<bool>("editMessageReplyMarkup", parameters, cancellationToken);
         }
 
         /// <summary>
@@ -1635,10 +1635,11 @@ namespace Telegram.Bot
                 throw new ApiRequestException("Request timed out", 408, e);
             }
             catch (HttpRequestException e)
-                when (e.Message.Contains("400") || e.Message.Contains("403") || e.Message.Contains("409")) {}
+                when (e.Message.Contains("400") || e.Message.Contains("403") || e.Message.Contains("409"))
+            { }
 
             if (responseObject == null)
-                responseObject = new ApiResponse<T> {Ok = false, Message = "No response received"};
+                responseObject = new ApiResponse<T> { Ok = false, Message = "No response received" };
 
             if (!responseObject.Ok)
                 throw ApiRequestException.FromApiResponse(responseObject);

--- a/src/Telegram.Bot/TelegramBotClient.cs
+++ b/src/Telegram.Bot/TelegramBotClient.cs
@@ -653,6 +653,7 @@ namespace Telegram.Bot
         /// <param name="chatId"><see cref="ChatId"/> for the target chat</param>
         /// <param name="videoNote">Video note to send.</param>
         /// <param name="duration">Duration of sent video in seconds</param>
+        /// <param name="length">Video width and height</param>
         /// <param name="disableNotification">Sends the message silently. iOS users will not receive a notification, Android users will receive a notification with no sound.</param>
         /// <param name="replyToMessageId">If the message is a reply, ID of the original message</param>
         /// <param name="replyMarkup">Additional interface options. A JSON-serialized object for a custom reply keyboard, instructions to hide keyboard or to force a reply from the user.</param>
@@ -661,15 +662,19 @@ namespace Telegram.Bot
         /// <see href="https://core.telegram.org/bots/api#sendvideonote"/>
         public Task<Message> SendVideoNoteAsync(ChatId chatId, FileToSend videoNote,
             int duration = 0,
+            int length = 0,
             bool disableNotification = false,
             int replyToMessageId = 0,
             IReplyMarkup replyMarkup = null,
             CancellationToken cancellationToken = default(CancellationToken))
         {
-            var additionalParameters = new Dictionary<string, object>
-            {
-                {"duration", duration},
-            };
+            var additionalParameters = new Dictionary<string, object>();
+
+            if (duration > 0)
+                additionalParameters.Add("duration", duration);
+
+            if (length > 0)
+                additionalParameters.Add("length", length);
 
             return SendMessageAsync(MessageType.VideoNoteMessage, chatId, videoNote, disableNotification, replyToMessageId,
                 replyMarkup, additionalParameters, cancellationToken);

--- a/src/Telegram.Bot/Types/Chat.cs
+++ b/src/Telegram.Bot/Types/Chat.cs
@@ -50,5 +50,23 @@ namespace Telegram.Bot.Types
         /// </summary>
         [JsonProperty(PropertyName = "all_members_are_administrators", Required = Required.Default)]
         public bool AllMembersAreAdministrators { get; set; }
+
+        /// <summary>
+        /// Optional. Chat photo. Returned only in getChat.
+        /// </summary>
+        [JsonProperty(PropertyName = "photo", Required = Required.Default)]
+        public ChatPhoto Photo { get; set; }
+
+        /// <summary>
+        /// Optional. Description, for supergroups and channel chats. Returned only in getChat.
+        /// </summary>
+        [JsonProperty(PropertyName = "description", Required = Required.Default)]
+        public string Description { get; set; }
+
+        /// <summary>
+        /// Optional. Chat invite link, for supergroups and channel chats. Returned only in getChat.
+        /// </summary>
+        [JsonProperty(PropertyName = "invite_link", Required = Required.Default)]
+        public string InviteLink { get; set; }
     }
 }

--- a/src/Telegram.Bot/Types/Chat.cs
+++ b/src/Telegram.Bot/Types/Chat.cs
@@ -13,7 +13,7 @@ namespace Telegram.Bot.Types
         /// Unique identifier for this chat, not exceeding 1e13 by absolute value
         /// </summary>
         [JsonProperty(PropertyName = "id", Required = Required.Always)]
-        public ChatId Id { get; set; }
+        public long Id { get; set; }
 
         /// <summary>
         /// Type of chat

--- a/src/Telegram.Bot/Types/ChatId.cs
+++ b/src/Telegram.Bot/Types/ChatId.cs
@@ -9,8 +9,15 @@ namespace Telegram.Bot.Types
     [JsonConverter(typeof(ChatIdConverter))]
     public class ChatId
     {
-        internal long Identifier;
-        internal string Username;
+        /// <summary>
+        /// Unique identifier for the chat
+        /// </summary>
+        public readonly long Identifier;
+
+        /// <summary>
+        /// Username of the channel (in the format @channelusername)
+        /// </summary>
+        public readonly string Username;
 
         /// <summary>
         /// Create a <see cref="ChatId"/> using an identifier
@@ -22,6 +29,15 @@ namespace Telegram.Bot.Types
         }
 
         /// <summary>
+        /// Create a <see cref="ChatId"/> using an identifier
+        /// </summary>
+        /// <param name="chatId">The Identifier</param>
+        public ChatId(int chatId)
+        {
+            Identifier = chatId;
+        }
+
+        /// <summary>
         /// Create a <see cref="ChatId"/> using an user name
         /// </summary>
         /// <param name="username">The user name</param>
@@ -30,6 +46,10 @@ namespace Telegram.Bot.Types
             if (username.Length > 1 && username.Substring(0, 1) == "@")
             {
                 Username = username;
+            }
+            else if (int.TryParse(username, out int chatId))
+            {
+                Identifier = chatId;
             }
             else if (long.TryParse(username, out long identifier))
             {
@@ -52,6 +72,12 @@ namespace Telegram.Bot.Types
         /// </summary>
         /// <param name="identifier">The identifier</param>
         public static implicit operator ChatId(long identifier) => new ChatId(identifier);
+
+        /// <summary>
+        /// Create a <see cref="ChatId"/> out of an identifier
+        /// </summary>
+        /// <param name="chatId">The identifier</param>
+        public static implicit operator ChatId(int chatId) => new ChatId(chatId);
 
         /// <summary>
         /// Create a <see cref="ChatId"/> out of an user name

--- a/src/Telegram.Bot/Types/ChatMember.cs
+++ b/src/Telegram.Bot/Types/ChatMember.cs
@@ -1,4 +1,6 @@
-﻿using Newtonsoft.Json;
+﻿using System;
+using Newtonsoft.Json;
+using Telegram.Bot.Converters;
 using Telegram.Bot.Types.Enums;
 
 namespace Telegram.Bot.Types
@@ -20,5 +22,90 @@ namespace Telegram.Bot.Types
         /// </summary>
         [JsonProperty("status", Required = Required.Always)]
         public ChatMemberStatus Status { get; set; }
+
+        /// <summary>
+        /// Optional. Restictred and kicked only. Date when restrictions will be lifted for this user, UTC time
+        /// </summary>
+        [JsonProperty(PropertyName = "until_date", Required = Required.Default)]
+        [JsonConverter(typeof(UnixDateTimeConverter))]
+        public DateTime UntilDate { get; set; }
+
+        /// <summary>
+        /// Optional. Administrators only. True, if the bot is allowed to edit administrator privileges of that user
+        /// </summary>
+        [JsonProperty(PropertyName = "can_be_edited", Required = Required.Default)]
+        public bool CanBeEdited { get; set; }
+
+        /// <summary>
+        /// Optional. Administrators only. True, if the administrator can change the chat title, photo and other settings
+        /// </summary>
+        [JsonProperty(PropertyName = "can_change_info", Required = Required.Default)]
+        public bool CanChangeInfo { get; set; }
+
+        /// <summary>
+        /// Optional. Administrators only. True, if the administrator can post in the channel, channels only
+        /// </summary>
+        [JsonProperty(PropertyName = "can_post_messages", Required = Required.Default)]
+        public bool CanPostMessages { get; set; }
+
+        /// <summary>
+        /// Optional. Administrators only. True, if the administrator can edit messages of other users, channels only
+        /// </summary>
+        [JsonProperty(PropertyName = "can_edit_messages", Required = Required.Default)]
+        public bool CanEditMessages { get; set; }
+
+        /// <summary>
+        /// Optional. Administrators only. True, if the administrator can delete messages of other users
+        /// </summary>
+        [JsonProperty(PropertyName = "can_delete_messages", Required = Required.Default)]
+        public bool CanDeleteMessages { get; set; }
+
+        /// <summary>
+        /// Optional. Administrators only. True, if the administrator can invite new users to the chat
+        /// </summary>
+        [JsonProperty(PropertyName = "can_invite_users", Required = Required.Default)]
+        public bool CanInviteUsers { get; set; }
+
+        /// <summary>
+        /// Optional. Administrators only. True, if the administrator can restrict, ban or unban chat members
+        /// </summary>
+        [JsonProperty(PropertyName = "can_restrict_members", Required = Required.Default)]
+        public bool CanRestrictMembers { get; set; }
+
+        /// <summary>
+        /// Optional. Administrators only. True, if the administrator can pin messages, supergroups only
+        /// </summary>
+        [JsonProperty(PropertyName = "can_pin_messages", Required = Required.Default)]
+        public bool CanPinMessages { get; set; }
+
+        /// <summary>
+        /// Optional. Administrators only. True, if the administrator can add new administrators with a subset of his own privileges or demote administrators that he has promoted, directly or indirectly (promoted by administrators that were appointed by the user)
+        /// </summary>
+        [JsonProperty(PropertyName = "can_promote_members", Required = Required.Default)]
+        public bool CanPromoteMembers { get; set; }
+
+        /// <summary>
+        /// Optional. Restricted only. True, if the user can send text messages, contacts, locations and venues
+        /// </summary>
+        [JsonProperty(PropertyName = "can_send_messages", Required = Required.Default)]
+        public bool CanSendMessages { get; set; }
+
+        /// <summary>
+        /// Optional. Restricted only. True, if the user can send audios, documents, photos, videos, video notes and voice notes, implies <see cref="CanSendMessages"/>
+        /// </summary>
+        [JsonProperty(PropertyName = "can_send_media_messages", Required = Required.Default)]
+        public bool CanSendMediaMessages { get; set; }
+
+        /// <summary>
+        /// Optional. Restricted only. True, if the user can send animations, games, stickers and use inline bots, implies <see cref="CanSendMediaMessages"/>
+        /// </summary>
+        [JsonProperty(PropertyName = "can_send_other_messages", Required = Required.Default)]
+        public bool CanSendOtherMessages { get; set; }
+
+        /// <summary>
+        /// Optional. Restricted only. True, if user may add web page previews to his messages, implies <see cref="CanSendMediaMessages"/>
+        /// </summary>
+        [JsonProperty(PropertyName = "can_add_web_page_previews", Required = Required.Default)]
+        public bool CanAddWebPagePreviews { get; set; }
     }
 }

--- a/src/Telegram.Bot/Types/ChatPhoto.cs
+++ b/src/Telegram.Bot/Types/ChatPhoto.cs
@@ -1,0 +1,22 @@
+﻿using Newtonsoft.Json;
+
+namespace Telegram.Bot.Types
+{
+    /// <summary>
+    /// Collection of fileIds of profile pictures of a chat.
+    /// </summary>
+    [JsonObject(MemberSerialization.OptIn)]
+    public class ChatPhoto
+    {
+        /// <summary>
+        /// File id of the big version of this <see cref="ChatPhoto"/>
+        /// </summary>
+        [JsonProperty(PropertyName = "big_file_id", Required = Required.Default)]
+        public string BigFileId { get; set; }
+        /// <summary>
+        /// File id of the small version of this <see cref="ChatPhoto"/>
+        /// </summary>
+        [JsonProperty(PropertyName = "small_file_id", Required = Required.Default)]
+        public string SmallFileId { get; set; }
+    }
+}

--- a/src/Telegram.Bot/Types/Message.cs
+++ b/src/Telegram.Bot/Types/Message.cs
@@ -305,6 +305,9 @@ namespace Telegram.Bot.Types
                 if (SuccessfulPayment != null)
                     return MessageType.SuccessfulPayment;
 
+                if (VideoNote != null)
+                    return MessageType.VideoNoteMessage;
+
                 if (NewChatMember != null ||
                     (NewChatMembers != null && NewChatMembers.Length > 0) ||
                     LeftChatMember != null ||

--- a/src/Telegram.Bot/Types/Update.cs
+++ b/src/Telegram.Bot/Types/Update.cs
@@ -82,7 +82,6 @@ namespace Telegram.Bot.Types
         /// <value>
         /// The update type.
         /// </value>
-        /// <exception cref="System.ArgumentOutOfRangeException"></exception>
         [JsonIgnore]
         public UpdateType Type
         {

--- a/src/Telegram.Bot/Types/User.cs
+++ b/src/Telegram.Bot/Types/User.cs
@@ -13,7 +13,7 @@ namespace Telegram.Bot.Types
         /// </summary>
         /// <returns></returns>
         [JsonProperty(PropertyName = "id", Required = Required.Always)]
-        public ChatId Id { get; set; }
+        public int Id { get; set; }
 
         /// <summary>
         /// User's or bot's first name

--- a/src/Telegram.Bot/Types/VideoNote.cs
+++ b/src/Telegram.Bot/Types/VideoNote.cs
@@ -8,11 +8,21 @@ namespace Telegram.Bot.Types
     [JsonObject(MemberSerialization.OptIn)]
     public class VideoNote : File
     {
-        // BUG: Don't think this is right in the documentation
         /// <summary>
         /// Video width and height as defined by sender
         /// </summary>
+        [JsonProperty("Length", Required = Required.Always)]
         public int Length { get; set; }
+
+        /// <summary>
+        /// Video width as defined by sender
+        /// </summary>
+        public int Width => Length;
+
+        /// <summary>
+        /// Video height as defined by sender
+        /// </summary>
+        public int Height => Length;
 
         /// <summary>
         /// Duration of the video in seconds as defined by sender


### PR DESCRIPTION
This fixes #385 where the multipart data contained the channel username surrounded with quotes, making the telegram API unable to find the channel to send to.