### PR TITLE
Fix #385

### DIFF
--- a/src/Telegram.Bot/TelegramBotClient.cs
+++ b/src/Telegram.Bot/TelegramBotClient.cs
@@ -1907,7 +1907,7 @@ namespace Telegram.Bot
                 case "FileToSend":
                     return new StreamContent(((FileToSend)value).Content);
                 default:
-                    return new StringContent(JsonConvert.SerializeObject(value, SerializerSettings));
+                    return new StringContent(JsonConvert.SerializeObject(value, SerializerSettings).Trim('"'));
             }
         }
         #endregion


### PR DESCRIPTION
This fixes #385 where the multipart data contained the channel username surrounded with quotes, making the telegram API unable to find the channel to send to.