### PR TITLE
Made it possible to create InlineKeyboardButtons without callback data

### DIFF
--- a/src/Telegram.Bot/Types/InlineKeyboardButton.cs
+++ b/src/Telegram.Bot/Types/InlineKeyboardButton.cs
@@ -83,7 +83,7 @@ namespace Telegram.Bot.Types
         /// </summary>
         /// <param name="text">The text.</param>
         /// <param name="callbackData">The callback data.</param>
-        public InlineKeyboardButton(string text, string callbackData) : this(text)
+        public InlineKeyboardButton(string text, string callbackData = null) : this(text)
         {
             CallbackData = callbackData;
         }


### PR DESCRIPTION
This way it's now easier again to create InlineKeyboardButtons that switch to an inline query, because otherwise the callback data would just override them.